### PR TITLE
Fix port handling and outdated dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@lmstudio/lms-common": "^0.5.7",
+        "@lmstudio/lms-common": "^0.6.0",
+        "@lmstudio/lms-isomorphic": "^0.3.2",
         "@lmstudio/lms-lmstudio": "^0.0.11",
         "@lmstudio/sdk": "^0.0.12",
         "boxen": "^5.1.2",
@@ -295,11 +296,13 @@
       }
     },
     "node_modules/@lmstudio/lms-common": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@lmstudio/lms-common/-/lms-common-0.5.2.tgz",
-      "integrity": "sha512-54n/WwfZQxPs4VZLLIdDnEHpNV68G3vZP9TlsBHv6+VBC71jEvd3RZ/rzkTc/VTjhb6zn/WBWtwGEwHzwmfDEQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@lmstudio/lms-common/-/lms-common-0.6.0.tgz",
+      "integrity": "sha512-0JNtaROYzrzOL5W7K2XSR5mvSmOQhUGWQ5TlGVoytLkvQOKPmn9husoNFlYOlHNo0aXQLOhN+bcmbkqL7RW1XQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@lmstudio/lms-shared-types": "^0.4.1",
+        "@lmstudio/lms-isomorphic": "^0.3.2",
+        "@lmstudio/lms-shared-types": "^0.5.0",
         "chalk": "^4.1.2",
         "immer": "^10.0.4",
         "process": "^0.11.10",
@@ -307,9 +310,10 @@
       }
     },
     "node_modules/@lmstudio/lms-isomorphic": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@lmstudio/lms-isomorphic/-/lms-isomorphic-0.3.1.tgz",
-      "integrity": "sha512-cEiL7d/mIZZ56gnU6hMQjyK2uOKYwCKjifEYM/r4WI/n+e+Vpbyn2WtvO/Y+3HjPa2nxTeGnavnnRUzV2wPPUA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@lmstudio/lms-isomorphic/-/lms-isomorphic-0.3.2.tgz",
+      "integrity": "sha512-haM4ZjDo6GWZtsvl5wJNAHEkBhxzbnuJhZGL0/ED0Nr1234PTfN7/ByoLTzCu3/6HUiPli5k33aEXkTCVd5rhw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",
         "utf-8-validate": "^6.0.3",
@@ -317,35 +321,57 @@
       }
     },
     "node_modules/@lmstudio/lms-lmstudio": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@lmstudio/lms-lmstudio/-/lms-lmstudio-0.0.5.tgz",
-      "integrity": "sha512-wr8EIevHLXJchXjzkSD2u1wtiNgor9qApeID3exsTcsS+DTEzx58FoK3SMWJGXpVrYItm/JTVP7NgguUFesVbw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@lmstudio/lms-lmstudio/-/lms-lmstudio-0.0.11.tgz",
+      "integrity": "sha512-bhA7BI6OhSEK3MbHUVr4P74QqvLnchpqBi/Zi/scL7OA+umq8/wJfZhlkMo8JPPnmlBYKED4Ro9tZoB3eA5EHg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@lmstudio/lms-common": "^0.5.2",
+        "@lmstudio/lms-common": "^0.5.7",
         "boxen": "^5.1.2",
         "chalk": "^4.1.2",
         "inquirer": "^8.2.6"
       }
     },
+    "node_modules/@lmstudio/lms-lmstudio/node_modules/@lmstudio/lms-common": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@lmstudio/lms-common/-/lms-common-0.5.7.tgz",
+      "integrity": "sha512-FHxBouniQAC9ovWMmMTZ1PGoQsFZwjMnJcKe+3eOqooF5w3q0aMKXqjUde1xKA3IvkrxBwQEDliM5uvcYpgAcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lmstudio/lms-isomorphic": "^0.3.2",
+        "@lmstudio/lms-shared-types": "^0.4.5",
+        "chalk": "^4.1.2",
+        "immer": "^10.0.4",
+        "process": "^0.11.10",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@lmstudio/lms-lmstudio/node_modules/@lmstudio/lms-shared-types": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@lmstudio/lms-shared-types/-/lms-shared-types-0.4.5.tgz",
+      "integrity": "sha512-I2ZUZkqAVhgCt0wueouDdzajvin9q5rJcgb2ZFtZg1efrO1nbM6LwDbYmweJt0h6nulBj/iG2S7Qd3PcJrL/bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
     "node_modules/@lmstudio/lms-shared-types": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@lmstudio/lms-shared-types/-/lms-shared-types-0.4.1.tgz",
-      "integrity": "sha512-eRhLhu57EKY52XK0GJE2xVMpDY2KWavsXlEHkrjSahvB07iXkqjE9Pkzc97rickLxTSIcZ/IyV4ZKDWl0yX4Pg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@lmstudio/lms-shared-types/-/lms-shared-types-0.5.0.tgz",
+      "integrity": "sha512-vDRJifggbortaK9BIoTuhbtqX/G/7kSiZQ/tL5Zrq4ScYAOWAcFgJ7pusG8Fq41YS0nn9/jx1JC0CHCmNBmT8A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@lmstudio/sdk": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@lmstudio/sdk/-/sdk-0.0.6.tgz",
-      "integrity": "sha512-7f2cuUwAJOhZPlmwuZRhG5eSp/Ng7MY4FISKA5c6uyRCXBymRkVRZpvE64d7jU4S17ximlqJEfHRtWgzDOhrkg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@lmstudio/sdk/-/sdk-0.0.12.tgz",
+      "integrity": "sha512-eAeCphpzLxcxVEk5XEU56cO/+A54x/vKV2kWKCvB319Cy1QrMXeVif8KA5M6Zw0m9gPOaRtVgQJ9xv/uMsMTfA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@lmstudio/lms-isomorphic": "^0.3.1",
-        "boxen": "^5.1.2",
-        "chalk": "^4.1.2",
-        "immer": "^10.0.4",
-        "process": "^0.11.10",
-        "zod": "^3.22.4"
+        "@lmstudio/lms-isomorphic": "^0.3.2",
+        "chalk": "^4.1.2"
       }
     },
     "node_modules/@microsoft/tsdoc": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "LM Studio <team@lmstudio.ai> (https://lmstudio.ai)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@lmstudio/lms-common": "^0.5.7",
+    "@lmstudio/lms-common": "^0.6.0",
     "@lmstudio/lms-isomorphic": "^0.3.2",
     "@lmstudio/lms-lmstudio": "^0.0.11",
     "@lmstudio/sdk": "^0.0.12",

--- a/src/subcommands/server.ts
+++ b/src/subcommands/server.ts
@@ -34,7 +34,7 @@ function getServerCtlPath() {
 }
 
 function getServerLastStatusPath() {
-  return path.join(os.homedir(), ".cache/lm-studio/.internal/http-server-last-status.json");
+  return path.join(os.homedir(), ".cache/lm-studio/.internal/http-server-config.json");
 }
 
 function getAppInstallLocationPath() {


### PR DESCRIPTION
Fixes #73 by replacing a nonexistent filepath and updates `@lmstudio/lms-common` to 0.6.0 to make it compile. Very few changes.