### PR TITLE
Switch to new immer and fix status/unload not working with embeddings

### DIFF
--- a/src/FileData.ts
+++ b/src/FileData.ts
@@ -5,7 +5,6 @@ import {
   type SimpleLogger,
   type StripNotAvailable,
 } from "@lmstudio/lms-common";
-
 import { existsSync, writeFileSync } from "fs";
 import { mkdir, readFile, watch } from "fs/promises";
 import path from "path";

--- a/src/subcommands/status.ts
+++ b/src/subcommands/status.ts
@@ -41,7 +41,9 @@ export const status = command({
       content += "\n\n";
 
       const client = await createClient(logger, args);
-      const loadedModels = await client.llm.listLoaded();
+      const loadedModels = (
+        await Promise.all([client.llm.listLoaded(), client.embedding.listLoaded()])
+      ).flat();
       const downloadedModels = await client.system.listDownloadedModels();
       content += chalk.cyanBright("Loaded Models");
       if (loadedModels.length === 0) {

--- a/src/subcommands/unload.ts
+++ b/src/subcommands/unload.ts
@@ -45,7 +45,9 @@ export const unload = command({
         ).message,
       );
     }
-    const models = await client.llm.listLoaded();
+    const models = (
+      await Promise.all([client.llm.listLoaded(), client.embedding.listLoaded()])
+    ).flat();
     const modelSearchStrings = models.map(({ identifier, path }) => {
       // The question mark here is a hack to apply gray color to the path part of the string.
       // It cannot be a part of the path, so we can find it by .lastIndexOf.


### PR DESCRIPTION
Switch to our "fork" of immer that has plugins enabled so we don't have to manage enabling plugins

Also fixes status/unload not working with embedding models.