### PR TITLE
Fix commands don't work if they woke LLM service

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Here are some frequently used commands:
   - `lms ls --json` - To list all downloaded models in machine-readable JSON format.
 - `lms ps` - To list all loaded models available for inferencing.
   - `lms ps --json` - To list all loaded models available for inferencing in machine-readable JSON format.
-- `lms load --gpu max` - To load a model with maximum GPU acceleration
-  - `lms load <model path> --gpu max -y` - To load a model with maximum GPU acceleration without confirmation
+- `lms load` - To load a model
+  - `lms load <model path> -y` - To load a model with maximum GPU acceleration without confirmation
 - `lms unload <model identifier>` - To unload a model
   - `lms unload --all` - To unload all models
 - `lms create` - To create a new project with LM Studio SDK

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -330,7 +330,7 @@ export const ps = command({
 
           To load a model, run:
 
-              ${chalk.yellow("lms load --gpu max")}${"\n"}
+              ${chalk.yellow("lms load")}${"\n"}
         `,
       );
       return;

--- a/src/subcommands/unload.ts
+++ b/src/subcommands/unload.ts
@@ -97,7 +97,7 @@ export const unload = command({
       logger.info(`Model "${identifier}" unloaded.`);
     } else {
       if (models.length === 0) {
-        logger.error(`You don't have any models loaded. Use "lms load --gpu max" to load a model.`);
+        logger.error(`You don't have any models loaded. Use "lms load" to load a model.`);
         process.exit(1);
       }
       console.info();


### PR DESCRIPTION
Launching LM Studio will cause the key to be rotated, thus we musts refetch the key if a command woke the service.