### PR TITLE
fix:bug issue_173

### DIFF
--- a/src/subcommands/server.ts
+++ b/src/subcommands/server.ts
@@ -257,13 +257,15 @@ const status = command({
     if (port !== null) {
       running = await checkHttpServer(logger, port);
     }
-    if (running) {
-      logger.info(`The server is running on port ${port}.`);
-    } else {
-      logger.info(`The server is not running.`);
-    }
+  
     if (json) {
       process.stdout.write(JSON.stringify({ running, port }) + "\n");
+    }else{
+      if (running) {
+        logger.info(`The server is running on port ${port}.`);
+      } else {
+        logger.info(`The server is not running.`);
+      }
     }
   },
 });


### PR DESCRIPTION
A validation has been added that checks if the json parameter is true and the running server message appears only in JSON and when there is no json parameter the normal flow is followed.