### PR TITLE
Remove hard coded white in lms version command.

### DIFF
--- a/src/subcommands/version.ts
+++ b/src/subcommands/version.ts
@@ -21,7 +21,7 @@ export function printVersion() {
   });
 
   console.info();
-  console.info(`\x1b[38;5;231mlms - LM Studio CLI - v${getVersion()}\x1b[0m`);
+  console.info(`lms - LM Studio CLI - v${getVersion()}\x1b[0m`);
   // console.info("Licensed under the MIT License");
   console.info(chalk.gray("GitHub: https://github.com/lmstudio-ai/lmstudio-cli"));
 }

--- a/src/subcommands/version.ts
+++ b/src/subcommands/version.ts
@@ -21,7 +21,7 @@ export function printVersion() {
   });
 
   console.info();
-  console.info(`lms - LM Studio CLI - v${getVersion()}\x1b[0m`);
+  console.info(`lms - LM Studio CLI - v${getVersion()}`);
   // console.info("Licensed under the MIT License");
   console.info(chalk.gray("GitHub: https://github.com/lmstudio-ai/lmstudio-cli"));
 }


### PR DESCRIPTION
Regarding the issue #202 

Work done : remove the hard coded WHITE color in the terminal.
So even if the user has a white background in its terminal preference, he can see the right version of lms.