### PR TITLE
Added a command to login with preauthenticated keys to lms login

### DIFF
--- a/src/subcommands/login.ts
+++ b/src/subcommands/login.ts
@@ -1,5 +1,6 @@
+import { text } from "@lmstudio/lms-common";
 import chalk from "chalk";
-import { command } from "cmd-ts";
+import { boolean, command, flag, option, optional, string } from "cmd-ts";
 import { createClient, createClientArgs } from "../createClient.js";
 import { createLogger, logLevelArgs } from "../logLevel.js";
 
@@ -7,12 +8,65 @@ export const login = command({
   name: "login",
   description: "Authenticate with LM Studio",
   args: {
+    withPreAuthenticatedKeys: flag({
+      type: boolean,
+      long: "with-pre-authenticated-keys",
+      description: text`
+        Authenticate using pre-authenticated keys. This is useful for CI/CD environments. You must
+        also provide the --key-id, --public-key, and --private-key flags.
+      `,
+    }),
+    keyId: option({
+      type: optional(string),
+      long: "key-id",
+      description: text`
+        The key ID to use for authentication. You should supply this if and only if you are using
+        --with-pre-authenticated-keys.
+      `,
+    }),
+    publicKey: option({
+      type: optional(string),
+      long: "public-key",
+      description: text`
+        The public key to use for authentication. You should supply this if and only if you are
+        using --with-pre-authenticated-keys.
+      `,
+    }),
+    privateKey: option({
+      type: optional(string),
+      long: "private-key",
+      description: text`
+        The private key to use for authentication. You should supply this if and only if you are
+        using --with-pre-authenticated-keys.
+      `,
+    }),
     ...logLevelArgs,
     ...createClientArgs,
   },
   handler: async args => {
     const logger = createLogger(args);
     const client = await createClient(logger, args);
+    const { withPreAuthenticatedKeys, keyId, publicKey, privateKey } = args;
+    if (withPreAuthenticatedKeys) {
+      if (keyId === undefined || publicKey === undefined || privateKey === undefined) {
+        throw new Error(text`
+          You must provide --key-id, --public-key, and --private-key when using
+          --with-pre-authenticated-keys.`);
+      }
+      const { userName } = await client.repository.loginWithPreAuthenticatedKeys({
+        keyId,
+        publicKey,
+        privateKey,
+      });
+      logger.info(`Successfully logged in as ${userName}.`);
+      return;
+    } else {
+      if (keyId !== undefined || publicKey !== undefined || privateKey !== undefined) {
+        throw new Error(text`
+          You must not provide --key-id, --public-key, or --private-key when not using
+          --with-pre-authenticated-keys.`);
+      }
+    }
     let askedToAuthenticate = false;
     await client.repository.ensureAuthenticated({
       onAuthenticationUrl: url => {


### PR DESCRIPTION
Added a series of flags/options: `--with-pre-authenticated-keys`, `--key-id <key id>`, `--public-key <public key>`, `--private-key <private key>` to support usage in CI.