### PR TITLE
Open auth URL automatically in browser on login

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "fuzzy": "^0.1.3",
     "inquirer": "^8.2.6",
     "inquirer-autocomplete-prompt": "^2.0.1",
+    "open": "^10.1.2",
     "tar": "^7.0.1",
     "yaml": "^2.7.1",
     "zod": "^3.22.4"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fuzzy": "^0.1.3",
     "inquirer": "^8.2.6",
     "inquirer-autocomplete-prompt": "^2.0.1",
-    "open": "^10.1.2",
+    "open": "^8.4.2",
     "tar": "^7.0.1",
     "yaml": "^2.7.1",
     "zod": "^3.22.4"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "fuzzy": "^0.1.3",
     "inquirer": "^8.2.6",
     "inquirer-autocomplete-prompt": "^2.0.1",
-    "open": "^8.4.2",
     "tar": "^7.0.1",
     "yaml": "^2.7.1",
     "zod": "^3.22.4"

--- a/src/openUrl.ts
+++ b/src/openUrl.ts
@@ -13,13 +13,6 @@ function getCommandForPlatform(): string {
   }
 }
 
-/**
- * Error handling is deliberately minimal, as this function is to be easy to use for shell scripting
- *
- * @param url The URL to open
- * @param callback A function with a single error argument. Optional.
- */
-
 export function openUrl(url: string, callback?: (error: Error | null) => void) {
   const command = getCommandForPlatform();
   const child = spawn(command, [url]);

--- a/src/openUrl.ts
+++ b/src/openUrl.ts
@@ -1,0 +1,46 @@
+import { spawn } from "child_process";
+
+function getCommandForPlatform(): string {
+  switch (process.platform) {
+    case "darwin":
+      return "open";
+    case "win32":
+      return "explorer.exe";
+    case "linux":
+      return "xdg-open";
+    default:
+      throw new Error("Unsupported platform: " + process.platform);
+  }
+}
+
+/**
+ * Error handling is deliberately minimal, as this function is to be easy to use for shell scripting
+ *
+ * @param url The URL to open
+ * @param callback A function with a single error argument. Optional.
+ */
+
+export function openUrl(url: string, callback?: (error: Error | null) => void) {
+  const command = getCommandForPlatform();
+  const child = spawn(command, [url]);
+  let errorText = "";
+
+  child.stderr.setEncoding("utf8");
+
+  child.stderr.on("data", function (data) {
+    errorText += data;
+  });
+
+  child.stderr.on("end", function () {
+    if (errorText.length > 0) {
+      const error = new Error(errorText);
+      if (callback) {
+        callback(error);
+      } else {
+        throw error;
+      }
+    } else if (callback) {
+      callback(null);
+    }
+  });
+}

--- a/src/subcommands/login.ts
+++ b/src/subcommands/login.ts
@@ -77,7 +77,11 @@ export const login = command({
         logger.info(chalk.greenBright(`    ${url}`));
         logger.info();
 
-        openUrl(url);
+        try {
+          openUrl(url);
+        } catch {
+          // ignore error
+        }
       },
     });
     if (!askedToAuthenticate) {

--- a/src/subcommands/login.ts
+++ b/src/subcommands/login.ts
@@ -70,18 +70,23 @@ export const login = command({
     }
     let askedToAuthenticate = false;
     await client.repository.ensureAuthenticated({
-      onAuthenticationUrl: url => {
+      onAuthenticationUrl: async url => {
         askedToAuthenticate = true;
-        logger.info("Opening browser for authentication... If a browser window does not open automatically, visit the following URL directly:");
+
+        try {
+          await openUrl(url);
+          logger.infoText`
+            Opening browser for authentication...
+            If a browser window does not open automatically, visit the following URL directly:
+          `
+          ;
+        } catch {
+          logger.info("Please visit the following URL to authenticate:");
+        }
+
         logger.info();
         logger.info(chalk.greenBright(`    ${url}`));
         logger.info();
-
-        try {
-          openUrl(url);
-        } catch {
-          // ignore error
-        }
       },
     });
     if (!askedToAuthenticate) {

--- a/src/subcommands/login.ts
+++ b/src/subcommands/login.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { boolean, command, flag, option, optional, string } from "cmd-ts";
 import { createClient, createClientArgs } from "../createClient.js";
 import { createLogger, logLevelArgs } from "../logLevel.js";
+import open from 'open';
 
 export const login = command({
   name: "login",
@@ -71,10 +72,12 @@ export const login = command({
     await client.repository.ensureAuthenticated({
       onAuthenticationUrl: url => {
         askedToAuthenticate = true;
-        logger.info("Please visit the following URL to authenticate:");
+        logger.info("Opening browser for authentication... If a browser window does not open automatically, visit the following URL directly:");
         logger.info();
         logger.info(chalk.greenBright(`    ${url}`));
         logger.info();
+
+        open(url);
       },
     });
     if (!askedToAuthenticate) {

--- a/src/subcommands/login.ts
+++ b/src/subcommands/login.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { boolean, command, flag, option, optional, string } from "cmd-ts";
 import { createClient, createClientArgs } from "../createClient.js";
 import { createLogger, logLevelArgs } from "../logLevel.js";
-import open from 'open';
+import { openUrl } from "../openUrl.js";
 
 export const login = command({
   name: "login",
@@ -77,7 +77,7 @@ export const login = command({
         logger.info(chalk.greenBright(`    ${url}`));
         logger.info();
 
-        open(url);
+        openUrl(url);
       },
     });
     if (!askedToAuthenticate) {


### PR DESCRIPTION
It's more convenient to open the auth URL automatically for users when they go to login from the CLI instead of having them manually copy and paste or click the URL themselves