### PR TITLE
Add .turbo to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tsconfig.tsbuildinfo
 coverage
 .env
 .DS_Store
+.turbo

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "clean": "shx rm -rf ./dist && shx rm -f ./tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf ./dist ./tsconfig.tsbuildinfo",
     "postinstall": "patch-package"
   },
   "engines": {


### PR DESCRIPTION
Follow on to https://github.com/lmstudio-ai/lmstudio-js/pull/349, we'll want to add `.turbo` to gitignore if we add support for turborepo