### PR TITLE
Check if moveCursor is present - non-tty support

### DIFF
--- a/src/subcommands/get.ts
+++ b/src/subcommands/get.ts
@@ -621,8 +621,9 @@ async function downloadArtifact(
   };
   let linesToClear: number = 0;
   const reprintDownloadPlan = (isFinished: boolean) => {
-    // Move cursor up by lastLines
-    if (process.stdout.moveCursor) {
+    // Check if we can move the cursor up (Not available in non TTY environments)
+    if (process.stdout.moveCursor !== undefined) {
+      // Move cursor up by lastLines
       process.stdout.moveCursor(0, -linesToClear);
     }
     const lines: Array<string> = [];

--- a/src/subcommands/get.ts
+++ b/src/subcommands/get.ts
@@ -622,7 +622,9 @@ async function downloadArtifact(
   let linesToClear: number = 0;
   const reprintDownloadPlan = (isFinished: boolean) => {
     // Move cursor up by lastLines
-    process.stdout.moveCursor(0, -linesToClear);
+    if (process.stdout.moveCursor) {
+      process.stdout.moveCursor(0, -linesToClear);
+    }
     const lines: Array<string> = [];
     const spinnerFrame = Math.floor(Date.now() / 100) % spinnerFrames.length;
     artifactDownloadPlanToString(downloadPlan, lines, spinnerFrame, 0, "   ", "  ");


### PR DESCRIPTION
Fixes the `lms get` command in a non-tty environment