### PR TITLE
Environment support for multiple hosts or ports

### DIFF
--- a/src/EnvironmentManager.ts
+++ b/src/EnvironmentManager.ts
@@ -134,6 +134,9 @@ export class EnvironmentManager {
   }
 
   public async tryGetEnvironment(name: string): Promise<EnvironmentConfig | undefined> {
+    if (name === DEFAULT_LOCAL_ENVIRONMENT_NAME) {
+      return DEFAULT_ENVIRONMENT_CONFIG; // Return default local environment
+    }
     await this.ensureDirExists();
     const envPath = join(this.environmentsDir, `${name}.json`);
     try {

--- a/src/EnvironmentManager.ts
+++ b/src/EnvironmentManager.ts
@@ -73,6 +73,11 @@ export class EnvironmentManager {
   }
 
   public async setCurrentEnvironment(name: string): Promise<void> {
+    if (name === "local") {
+      // Special case for local environment
+      await fs.writeFile(this.currentEnvFile, DEFAULT_LOCAL_ENVIRONMENT_NAME, "utf-8");
+      return;
+    }
     const envPath = join(this.environmentsDir, `${name}.json`);
     try {
       const data = await fs.readFile(envPath, "utf-8");
@@ -86,7 +91,13 @@ export class EnvironmentManager {
   public async getCurrentEnvironment(): Promise<EnvironmentConfig> {
     let envName: string;
 
-    if (process.env.LMS_ENV) {
+    // Check if LMS_ENV is set in the environment variables
+    // This takes precedence over the currentEnvFile
+    if (
+      process.env.LMS_ENV &&
+      process.env.LMS_ENV !== "undefined" &&
+      process.env.LMS_ENV !== "null"
+    ) {
       envName = process.env.LMS_ENV;
     } else {
       try {

--- a/src/EnvironmentManager.ts
+++ b/src/EnvironmentManager.ts
@@ -53,11 +53,20 @@ export class EnvironmentManager {
           await fs.writeFile(this.currentEnvFile, "local", "utf-8");
           process.env.LMS_ENV = "local";
         }
-      } catch {
-        // Current env file doesn't exist, nothing to update
+      } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+          await fs.writeFile(this.currentEnvFile, "local", "utf-8");
+        } else {
+          // Re-throw other types of errors
+          throw error;
+        }
       }
-    } catch {
-      throw new Error(`Environment ${name} does not exist.`);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        throw new Error(`Environment ${name} does not exist.`);
+      } else {
+        throw new Error(`Failed to remove environment ${name}: ${(error as Error).message}`);
+      }
     }
   }
 

--- a/src/EnvironmentManager.ts
+++ b/src/EnvironmentManager.ts
@@ -10,8 +10,10 @@ interface EnvironmentConfig {
   executablePath?: string;
 }
 
+export const DEFAULT_LOCAL_ENVIRONMENT_NAME = "local";
+
 const DEFAULT_ENVIRONMENT_CONFIG: EnvironmentConfig = {
-  name: "local",
+  name: DEFAULT_LOCAL_ENVIRONMENT_NAME,
   host: "localhost",
   port: 1234,
   description: "Default local environment",
@@ -50,12 +52,12 @@ export class EnvironmentManager {
       try {
         const currentEnv = await fs.readFile(this.currentEnvFile, "utf-8");
         if (currentEnv === name) {
-          await fs.writeFile(this.currentEnvFile, "local", "utf-8");
-          process.env.LMS_ENV = "local";
+          await fs.writeFile(this.currentEnvFile, DEFAULT_LOCAL_ENVIRONMENT_NAME, "utf-8");
+          process.env.LMS_ENV = DEFAULT_LOCAL_ENVIRONMENT_NAME;
         }
       } catch (error) {
         if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-          await fs.writeFile(this.currentEnvFile, "local", "utf-8");
+          await fs.writeFile(this.currentEnvFile, DEFAULT_LOCAL_ENVIRONMENT_NAME, "utf-8");
         } else {
           // Re-throw other types of errors
           throw error;
@@ -90,17 +92,17 @@ export class EnvironmentManager {
       try {
         envName = (await fs.readFile(this.currentEnvFile, "utf-8")).trim();
       } catch {
-        envName = "local";
+        envName = DEFAULT_LOCAL_ENVIRONMENT_NAME;
       }
     }
-    if (envName === undefined || envName === "" || envName === "local") {
+    if (envName === undefined || envName === "" || envName === DEFAULT_LOCAL_ENVIRONMENT_NAME) {
       return DEFAULT_ENVIRONMENT_CONFIG;
     }
 
     const env = await this.tryGetEnvironment(envName);
     if (env === undefined) {
       console.warn(`Environment ${envName} not found, falling back to local.`);
-      await fs.writeFile(this.currentEnvFile, "local", "utf-8");
+      await fs.writeFile(this.currentEnvFile, DEFAULT_LOCAL_ENVIRONMENT_NAME, "utf-8");
       return DEFAULT_ENVIRONMENT_CONFIG;
     }
 

--- a/src/EnvironmentManager.ts
+++ b/src/EnvironmentManager.ts
@@ -132,7 +132,7 @@ export class EnvironmentManager {
           const parsed = environmentConfigSchema.parse(JSON.parse(data));
           environments.push(parsed);
         } catch (error) {
-          this.logger.error(`Failed to load environment from ${file}: ${(error as Error).message}`);
+          this.logger.warn(`Failed to load environment from ${file}: ${(error as Error).message}`);
         }
       }
     }

--- a/src/EnvironmentManager.ts
+++ b/src/EnvironmentManager.ts
@@ -1,0 +1,124 @@
+import { promises as fs } from "fs";
+import { join } from "path";
+import { lmsConfigFolder } from "./lmstudioPaths.js";
+
+interface EnvironmentConfig {
+  name: string;
+  host: string;
+  port: number;
+  description?: string;
+  executablePath?: string;
+}
+
+const DEFAULT_ENVIRONMENT_CONFIG: EnvironmentConfig = {
+  name: "local",
+  host: "localhost",
+  port: 1234,
+  description: "Default local environment",
+};
+
+export class EnvironmentManager {
+  private environmentsDir: string;
+  private currentEnvFile: string;
+
+  public constructor() {
+    const configDir = lmsConfigFolder;
+    this.environmentsDir = join(configDir, "environments");
+    this.currentEnvFile = join(configDir, "current-env");
+  }
+
+  private async ensureDirExists(): Promise<void> {
+    await fs.mkdir(this.environmentsDir, { recursive: true });
+  }
+
+  public async addEnvironment(config: EnvironmentConfig): Promise<void> {
+    await this.ensureDirExists();
+    const envPath = join(this.environmentsDir, `${config.name}.json`);
+    try {
+      await fs.access(envPath);
+      throw new Error(`Environment ${config.name} already exists.`);
+    } catch {
+      await fs.writeFile(envPath, JSON.stringify(config, null, 2), "utf-8");
+    }
+  }
+
+  public async removeEnvironment(name: string): Promise<void> {
+    const envPath = join(this.environmentsDir, `${name}.json`);
+    try {
+      await fs.unlink(envPath);
+      // Check if this was the current environment
+      try {
+        const currentEnv = await fs.readFile(this.currentEnvFile, "utf-8");
+        if (currentEnv === name) {
+          await fs.writeFile(this.currentEnvFile, "local", "utf-8");
+          process.env.LMS_ENV = "local";
+        }
+      } catch {
+        // Current env file doesn't exist, nothing to update
+      }
+    } catch {
+      throw new Error(`Environment ${name} does not exist.`);
+    }
+  }
+
+  public async setCurrentEnvironment(name: string): Promise<void> {
+    const envPath = join(this.environmentsDir, `${name}.json`);
+    try {
+      const data = await fs.readFile(envPath, "utf-8");
+      JSON.parse(data) as EnvironmentConfig; // Validate exists
+      await fs.writeFile(this.currentEnvFile, name, "utf-8");
+    } catch {
+      throw new Error(`Environment ${name} does not exist.`);
+    }
+  }
+
+  public async getCurrentEnvironment(): Promise<EnvironmentConfig> {
+    let envName: string;
+
+    if (process.env.LMS_ENV) {
+      envName = process.env.LMS_ENV;
+    } else {
+      try {
+        envName = (await fs.readFile(this.currentEnvFile, "utf-8")).trim();
+      } catch {
+        envName = "local";
+      }
+    }
+    if (envName === undefined || envName === "" || envName === "local") {
+      return DEFAULT_ENVIRONMENT_CONFIG;
+    }
+
+    const env = await this.tryGetEnvironment(envName);
+    if (env === undefined) {
+      console.warn(`Environment ${envName} not found, falling back to local.`);
+      await fs.writeFile(this.currentEnvFile, "local", "utf-8");
+      return DEFAULT_ENVIRONMENT_CONFIG;
+    }
+
+    return env;
+  }
+
+  public async getAllEnvironments(): Promise<EnvironmentConfig[]> {
+    await this.ensureDirExists();
+    const files = await fs.readdir(this.environmentsDir);
+    const environments: EnvironmentConfig[] = [DEFAULT_ENVIRONMENT_CONFIG];
+    for (const file of files) {
+      if (file.endsWith(".json")) {
+        const data = await fs.readFile(join(this.environmentsDir, file), "utf-8");
+        environments.push(JSON.parse(data) as EnvironmentConfig);
+      }
+    }
+    return environments;
+  }
+
+  public async tryGetEnvironment(name: string): Promise<EnvironmentConfig | undefined> {
+    await this.ensureDirExists();
+    const envPath = join(this.environmentsDir, `${name}.json`);
+    try {
+      const data = await fs.readFile(envPath, "utf-8");
+      return JSON.parse(data) as EnvironmentConfig;
+    } catch {
+      return undefined; // Environment does not exist
+    }
+  }
+}

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -19,11 +19,11 @@ export const createClientArgs = {
     type: optional(string),
     long: "env",
     description: text`
-        If you wish to connect to a remote LM Studio instance, specify the env here. Note that, in
-        this case, lms will connect using client identifier "lms-cli-remote-<random chars>", which
-        will not be a privileged client, and will restrict usage of functionalities such as
-        "lms push".  Know more about envs using lms env.
-      `,
+      If you wish to connect to a remote LM Studio instance, specify the env here. Note that, in
+      this case, lms will connect using client identifier "lms-cli-remote-<random chars>", which
+      will not be a privileged client, and will restrict usage of functionalities such as
+      "lms push".  Know more about envs using lms env.
+    `,
   }),
 };
 

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1,6 +1,5 @@
 import { apiServerPorts, type SimpleLogger, text } from "@lmstudio/lms-common";
 import { LMStudioClient, type LMStudioClientConstructorOpts } from "@lmstudio/sdk";
-
 import { spawn } from "child_process";
 import { randomBytes } from "crypto";
 import { readFile } from "fs/promises";

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1,14 +1,13 @@
 import { apiServerPorts, type SimpleLogger, text } from "@lmstudio/lms-common";
 import { LMStudioClient, type LMStudioClientConstructorOpts } from "@lmstudio/sdk";
-import chalk from "chalk";
+
 import { spawn } from "child_process";
-import { option, optional, string } from "cmd-ts";
 import { randomBytes } from "crypto";
 import { readFile } from "fs/promises";
 import { appInstallLocationFilePath, lmsKey2Path } from "./lmstudioPaths.js";
 import { type LogLevelArgs } from "./logLevel.js";
 import { checkHttpServer } from "./subcommands/server.js";
-import { refinedNumber } from "./types/refinedNumber.js";
+import { EnvironmentManager } from "./EnvironmentManager.js";
 
 interface AppInstallLocation {
   path: string;
@@ -16,31 +15,10 @@ interface AppInstallLocation {
   cwd: string;
 }
 
-export const createClientArgs = {
-  host: option({
-    type: optional(string),
-    long: "host",
-    description: text`
-      If you wish to connect to a remote LM Studio instance, specify the host here. Note that, in
-      this case, lms will connect using client identifier "lms-cli-remote-<random chars>", which
-      will not be a privileged client, and will restrict usage of functionalities such as
-      "lms push".
-    `,
-  }),
-  port: option({
-    type: optional(refinedNumber({ integer: true, min: 0, max: 65535 })),
-    long: "port",
-    description: text`
-      The port where LM Studio can be reached. If not provided and the host is set to "127.0.0.1"
-      (default), the last used port will be used; otherwise, 1234 will be used.
-    `,
-  }),
-};
+export const createClientArgs = {};
 
 interface CreateClientArgs {
   yes?: boolean;
-  host?: string;
-  port?: number;
 }
 
 async function isLocalServerAtPortLMStudioServerOrThrow(port: number) {
@@ -107,20 +85,12 @@ export async function createClient(
   args: CreateClientArgs & LogLevelArgs,
   _opts: CreateClientOpts = {},
 ) {
-  let { host, port } = args;
-  let isRemote = true;
-  if (host === undefined) {
-    isRemote = false;
-    host = "127.0.0.1";
-  } else if (host.includes("://")) {
-    logger.error("Host should not include the protocol.");
-    process.exit(1);
-  } else if (host.includes(":")) {
-    logger.error(
-      `Host should not include the port number. Use ${chalk.yellowBright("--port")} instead.`,
-    );
-    process.exit(1);
-  }
+  const envManager = new EnvironmentManager();
+  const currentEnv = await envManager.getCurrentEnvironment();
+  const host = currentEnv.host;
+  const port = currentEnv.port;
+
+  const isRemote = host !== "127.0.0.1" && host !== "localhost";
   let auth: LMStudioClientConstructorOpts;
   if (isRemote) {
     // If connecting to a remote server, we will use a random client identifier.
@@ -146,7 +116,7 @@ export async function createClient(
       };
     }
   }
-  if (port === undefined && host === "127.0.0.1") {
+  if (host === "127.0.0.1" || host === "localhost") {
     // We will now attempt to connect to the local API server.
     const localPort = await tryFindLocalAPIServer();
 
@@ -186,11 +156,6 @@ export async function createClient(
 
     logger.error("");
   }
-
-  if (port === undefined) {
-    port = 1234;
-  }
-
   logger.debug(`Connecting to server at ${host}:${port}`);
   if (!(await checkHttpServer(logger, port, host))) {
     logger.error(

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -6,7 +6,7 @@ import { readFile } from "fs/promises";
 import { appInstallLocationFilePath, lmsKey2Path } from "./lmstudioPaths.js";
 import { type LogLevelArgs } from "./logLevel.js";
 import { checkHttpServer } from "./subcommands/server.js";
-import { EnvironmentManager } from "./EnvironmentManager.js";
+import { DEFAULT_LOCAL_ENVIRONMENT_NAME, EnvironmentManager } from "./EnvironmentManager.js";
 
 interface AppInstallLocation {
   path: string;
@@ -89,7 +89,7 @@ export async function createClient(
   const host = currentEnv.host;
   const port = currentEnv.port;
 
-  const isRemote = host !== "127.0.0.1" && host !== "localhost";
+  const isRemote = currentEnv.name !== DEFAULT_LOCAL_ENVIRONMENT_NAME;
   let auth: LMStudioClientConstructorOpts;
   if (isRemote) {
     // If connecting to a remote server, we will use a random client identifier.
@@ -115,7 +115,7 @@ export async function createClient(
       };
     }
   }
-  if (host === "127.0.0.1" || host === "localhost") {
+  if (isRemote === false) {
     // We will now attempt to connect to the local API server.
     const localPort = await tryFindLocalAPIServer();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { server } from "./subcommands/server.js";
 import { status } from "./subcommands/status.js";
 import { unload } from "./subcommands/unload.js";
 import { printVersion, version } from "./subcommands/version.js";
+import { env } from "./subcommands/env.js";
 
 if (process.argv.length === 2) {
   printVersion();
@@ -44,6 +45,7 @@ const cli = subcommands({
     flags: flagsCommand,
     bootstrap,
     version,
+    env,
   },
 });
 

--- a/src/lmstudioPaths.ts
+++ b/src/lmstudioPaths.ts
@@ -2,6 +2,7 @@ import { findLMStudioHome } from "@lmstudio/lms-common-server";
 import { join } from "path";
 
 const lmstudioHome = findLMStudioHome();
+export const lmsConfigFolder = join(lmstudioHome, "lms"); //TODO: Temporary path
 export const pluginsFolderPath = join(lmstudioHome, "extensions", "plugins");
 export const lmsKey2Path = join(lmstudioHome, ".internal", "lms-key-2");
 export const cliPrefPath = join(lmstudioHome, ".internal", "cli-pref.json");

--- a/src/subcommands/env.ts
+++ b/src/subcommands/env.ts
@@ -126,13 +126,6 @@ const useEnvCommand = command({
     const logger = createLogger(logArgs);
     const envManager = new EnvironmentManager();
     try {
-      if (name === "local") {
-        // Special case for local environment
-        process.env.LMS_ENV = "local";
-        logger.info("Switched to local environment");
-        return;
-      }
-
       await envManager.setCurrentEnvironment(name);
       logger.info(`Switched to environment '${name}'`);
     } catch (error) {

--- a/src/subcommands/env.ts
+++ b/src/subcommands/env.ts
@@ -1,0 +1,178 @@
+import { text } from "@lmstudio/lms-common";
+import { command, option, optional, positional, string, subcommands } from "cmd-ts";
+import { EnvironmentManager } from "../EnvironmentManager.js";
+import { createLogger, logLevelArgs } from "../logLevel.js";
+import { refinedNumber } from "../types/refinedNumber.js";
+
+const addEnvCommand = command({
+  name: "add",
+  description: "Add a new environment",
+  args: {
+    name: positional({
+      type: string,
+      displayName: "name",
+      description: "Environment name",
+    }),
+    host: option({
+      type: string,
+      long: "host",
+      description: "Host address",
+    }),
+    port: option({
+      type: refinedNumber({ integer: true, min: 0, max: 65535 }),
+      long: "port",
+      description: "Port number",
+    }),
+    description: option({
+      type: optional(string),
+      long: "description",
+      description: "Environment description",
+    }),
+    ...logLevelArgs,
+  },
+  handler: async ({ name, host, port, description, ...logArgs }) => {
+    const logger = createLogger(logArgs);
+    const envManager = new EnvironmentManager();
+    try {
+      await envManager.addEnvironment({
+        name,
+        host,
+        port,
+        description,
+      });
+      logger.info(`Environment '${name}' added successfully`);
+    } catch (error) {
+      logger.error(`Failed to add environment: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  },
+});
+
+const removeEnvCommand = command({
+  name: "remove",
+  description: "Remove an environment",
+  args: {
+    name: positional({
+      type: string,
+      displayName: "name",
+      description: "Environment name to remove",
+    }),
+    ...logLevelArgs,
+  },
+  handler: async ({ name, ...logArgs }) => {
+    const logger = createLogger(logArgs);
+    const envManager = new EnvironmentManager();
+    try {
+      await envManager.removeEnvironment(name);
+      logger.info(`Environment '${name}' removed successfully`);
+    } catch (error) {
+      logger.error(`Failed to remove environment: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  },
+});
+
+const listEnvCommand = command({
+  name: "ls",
+  description: "List all environments",
+  args: {
+    ...logLevelArgs,
+  },
+  handler: async logArgs => {
+    const logger = createLogger(logArgs);
+    const envManager = new EnvironmentManager();
+    try {
+      const environments = await envManager.getAllEnvironments();
+      const current = await envManager.getCurrentEnvironment();
+
+      if (environments.length === 0) {
+        logger.info("No environments found");
+        return;
+      }
+
+      logger.info("Available environments:");
+      for (const env of environments) {
+        const isCurrent = env.name === current.name;
+        const marker = isCurrent ? "* " : "  ";
+        const desc = env.description ? ` - ${env.description}` : "";
+        logger.info(`${marker}${env.name} (${env.host}:${env.port})${desc}`);
+      }
+
+      // Show default local environment if not in list
+      const hasLocal = environments.some(env => env.name === "local");
+      if (!hasLocal) {
+        const marker = current.name === "local" ? "* " : "  ";
+        logger.info(`${marker}local (localhost:1234) - Default local environment`);
+      }
+    } catch (error) {
+      logger.error(`Failed to list environments: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  },
+});
+
+const useEnvCommand = command({
+  name: "use",
+  description: "Switch to an environment",
+  args: {
+    name: positional({
+      type: string,
+      displayName: "name",
+      description: "Environment name to switch to",
+    }),
+    ...logLevelArgs,
+  },
+  handler: async ({ name, ...logArgs }) => {
+    const logger = createLogger(logArgs);
+    const envManager = new EnvironmentManager();
+    try {
+      if (name === "local") {
+        // Special case for local environment
+        process.env.LMS_ENV = "local";
+        logger.info("Switched to local environment");
+        return;
+      }
+
+      await envManager.setCurrentEnvironment(name);
+      logger.info(`Switched to environment '${name}'`);
+    } catch (error) {
+      logger.error(`Failed to switch environment: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  },
+});
+
+const currentEnvCommand = command({
+  name: "current",
+  description: "Show current environment",
+  args: {
+    ...logLevelArgs,
+  },
+  handler: async logArgs => {
+    const logger = createLogger(logArgs);
+    const envManager = new EnvironmentManager();
+    try {
+      const current = await envManager.getCurrentEnvironment();
+      const desc = current.description ? ` - ${current.description}` : "";
+      logger.info(`Current environment: ${current.name} (${current.host}:${current.port})${desc}`);
+    } catch (error) {
+      logger.error(`Failed to get current environment: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  },
+});
+
+export const env = subcommands({
+  name: "env",
+  description: text`
+    Manage LM Studio environments. Environments allow you to switch between different
+    LM Studio instances (local or remote) easily.
+  `,
+  cmds: {
+    add: addEnvCommand,
+    remove: removeEnvCommand,
+    list: listEnvCommand,
+    use: useEnvCommand,
+    current: currentEnvCommand,
+  },
+});

--- a/src/subcommands/env.ts
+++ b/src/subcommands/env.ts
@@ -171,7 +171,7 @@ export const env = subcommands({
   cmds: {
     add: addEnvCommand,
     remove: removeEnvCommand,
-    list: listEnvCommand,
+    ls: listEnvCommand,
     use: useEnvCommand,
     current: currentEnvCommand,
   },

--- a/src/subcommands/env.ts
+++ b/src/subcommands/env.ts
@@ -32,7 +32,7 @@ const addEnvCommand = command({
   },
   handler: async ({ name, host, port, description, ...logArgs }) => {
     const logger = createLogger(logArgs);
-    const envManager = new EnvironmentManager();
+    const envManager = new EnvironmentManager(logger);
     try {
       await envManager.addEnvironment({
         name,
@@ -61,7 +61,7 @@ const removeEnvCommand = command({
   },
   handler: async ({ name, ...logArgs }) => {
     const logger = createLogger(logArgs);
-    const envManager = new EnvironmentManager();
+    const envManager = new EnvironmentManager(logger);
     try {
       await envManager.removeEnvironment(name);
       logger.info(`Environment '${name}' removed successfully`);
@@ -80,7 +80,7 @@ const listEnvCommand = command({
   },
   handler: async logArgs => {
     const logger = createLogger(logArgs);
-    const envManager = new EnvironmentManager();
+    const envManager = new EnvironmentManager(logger);
     try {
       const environments = await envManager.getAllEnvironments();
       const current = await envManager.getCurrentEnvironment();
@@ -124,7 +124,7 @@ const useEnvCommand = command({
   },
   handler: async ({ name, ...logArgs }) => {
     const logger = createLogger(logArgs);
-    const envManager = new EnvironmentManager();
+    const envManager = new EnvironmentManager(logger);
     try {
       await envManager.setCurrentEnvironment(name);
       logger.info(`Switched to environment '${name}'`);
@@ -143,7 +143,7 @@ const currentEnvCommand = command({
   },
   handler: async logArgs => {
     const logger = createLogger(logArgs);
-    const envManager = new EnvironmentManager();
+    const envManager = new EnvironmentManager(logger);
     try {
       const current = await envManager.getCurrentEnvironment();
       const desc = current.description ? ` - ${current.description}` : "";
@@ -168,7 +168,7 @@ const inspectEnvCommand = command({
   },
   handler: async ({ name, ...logArgs }) => {
     const logger = createLogger(logArgs);
-    const envManager = new EnvironmentManager();
+    const envManager = new EnvironmentManager(logger);
     try {
       const env = await envManager.tryGetEnvironment(name);
       if (!env) {
@@ -179,11 +179,8 @@ const inspectEnvCommand = command({
       logger.info(`Environment: ${env.name}`);
       logger.info(`Host: ${env.host}`);
       logger.info(`Port: ${env.port}`);
-      if (env.description) {
+      if (env.description !== undefined) {
         logger.info(`Description: ${env.description}`);
-      }
-      if (env.executablePath) {
-        logger.info(`Executable Path: ${env.executablePath}`);
       }
     } catch (error) {
       logger.error(`Failed to inspect environment: ${(error as Error).message}`);

--- a/src/subcommands/env.ts
+++ b/src/subcommands/env.ts
@@ -155,6 +155,43 @@ const currentEnvCommand = command({
   },
 });
 
+const inspectEnvCommand = command({
+  name: "inspect",
+  description: "Show detailed information about an environment",
+  args: {
+    name: positional({
+      type: string,
+      displayName: "name",
+      description: "Environment name to inspect",
+    }),
+    ...logLevelArgs,
+  },
+  handler: async ({ name, ...logArgs }) => {
+    const logger = createLogger(logArgs);
+    const envManager = new EnvironmentManager();
+    try {
+      const env = await envManager.tryGetEnvironment(name);
+      if (!env) {
+        logger.error(`Environment '${name}' not found`);
+        process.exit(1);
+      }
+
+      logger.info(`Environment: ${env.name}`);
+      logger.info(`Host: ${env.host}`);
+      logger.info(`Port: ${env.port}`);
+      if (env.description) {
+        logger.info(`Description: ${env.description}`);
+      }
+      if (env.executablePath) {
+        logger.info(`Executable Path: ${env.executablePath}`);
+      }
+    } catch (error) {
+      logger.error(`Failed to inspect environment: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  },
+});
+
 export const env = subcommands({
   name: "env",
   description: text`
@@ -167,5 +204,6 @@ export const env = subcommands({
     ls: listEnvCommand,
     use: useEnvCommand,
     current: currentEnvCommand,
+    inspect: inspectEnvCommand,
   },
 });

--- a/src/subcommands/status.ts
+++ b/src/subcommands/status.ts
@@ -2,36 +2,24 @@ import { text } from "@lmstudio/lms-common";
 import boxen from "boxen";
 import chalk from "chalk";
 import { command } from "cmd-ts";
-import { createClient, createClientArgs } from "../createClient.js";
+import { createClient } from "../createClient.js";
+import { EnvironmentManager } from "../EnvironmentManager.js";
 import { formatSizeBytesWithColor1000 } from "../formatSizeBytes1000.js";
 import { createLogger, logLevelArgs } from "../logLevel.js";
-import { checkHttpServer, getServerConfig } from "./server.js";
+import { checkHttpServer } from "./server.js";
 
 export const status = command({
   name: "status",
   description: "Prints the status of LM Studio",
   args: {
     ...logLevelArgs,
-    ...createClientArgs,
   },
   async handler(args) {
     const logger = createLogger(args);
-    let { host, port } = args;
-    if (host === undefined) {
-      host = "127.0.0.1";
-    }
-    if (port === undefined) {
-      if (host === "127.0.0.1") {
-        try {
-          port = (await getServerConfig(logger)).port;
-        } catch (e) {
-          logger.debug(`Failed to read last status`, e);
-          port = 1234;
-        }
-      } else {
-        port = 1234;
-      }
-    }
+    const envManager = new EnvironmentManager();
+    const currentEnv = await envManager.getCurrentEnvironment();
+    const host = currentEnv.host;
+    const port = currentEnv.port;
     const running = await checkHttpServer(logger, port, host);
     let content = "";
     if (running) {

--- a/src/subcommands/status.ts
+++ b/src/subcommands/status.ts
@@ -16,7 +16,7 @@ export const status = command({
   },
   async handler(args) {
     const logger = createLogger(args);
-    const envManager = new EnvironmentManager();
+    const envManager = new EnvironmentManager(logger);
     const currentEnv = await envManager.getCurrentEnvironment();
     const host = currentEnv.host;
     const port = currentEnv.port;


### PR DESCRIPTION
## Overview

Instead of specifying `--host --port` to make a request to a LM Studio running on other address and to make `lms` easy to use with multiple lmstudio instances in general, this PR brings in a new feature of 'environments' which are pretty similar to `docker context`

### What commands does it bring?
• `lms env add <name> --host <host> --port <port> [--description <desc>]` - Add a new environment
• `lms env remove <name>` - Remove an environment  
• `lms env ls`- List all environments (shows current with *)
• `lms env use <name>`- Switch to an environment
• `lms env current` - Show current environment details
• `lms env inspect <name>` - Show detailed information about a specific environment

### Breaking Changes

Removes the `--host` and `--port` argument

### How does it work?

It creates a new folder - `.lmstudio/lms` which has two things 
1. `current-env`: store the name of the current environment
2. `environments`: store all the environment JSON files

#### Example JSON file for an environment

```json
{
  "name": "remote",
  "host": "localhost",
  "port": 5678,
  "description": "A remote instance of LM Studio"
}
```

### Screenshots of how it works

1. Using the default `local` environment

<img width="809" height="965" alt="image" src="https://github.com/user-attachments/assets/a36d1378-2a01-4d3c-9e96-062703f2724e" />

2. Switching the a dummy remote instance of LM studio running on some other port

<img width="811" height="571" alt="image" src="https://github.com/user-attachments/assets/1484b5c2-7591-4484-975b-b8d7e9f49fa3" />

3. Removing a env
<img width="568" height="315" alt="image" src="https://github.com/user-attachments/assets/346c37cd-ec58-47b0-8f89-53ee9eb09781" />

4. `LMS_ENV` support 
<img width="550" height="320" alt="image" src="https://github.com/user-attachments/assets/35fb1bd0-50e0-4ee8-b9b0-6698755dbd2a" />

5. Inspect Command
<img width="562" height="333" alt="image" src="https://github.com/user-attachments/assets/9ef1fbf8-7a40-45fa-8a87-27c2b9a58d56" />
