### PR TITLE
Add Command and Option Groups

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -46,6 +46,12 @@ interface AppInstallLocation {
 
 /**
  * Adds create client options to a commander.js command
+ *
+ * This creates an Options Group. If other options are added without defining their own group,
+ * then they will be (likely erroneously) added to the this group.
+ * To avoid this, developers should either:
+ *   1. Define an options group before adding subsequent options
+ *   2. Add all options _before_ adding this group
  */
 export function addCreateClientOptions<
   Args extends any[],
@@ -53,6 +59,7 @@ export function addCreateClientOptions<
   GlobalOpts extends OptionValues,
 >(command: Command<Args, Opts, GlobalOpts>) {
   return command
+    .optionsGroup("Instance Options:")
     .option(
       "--host <host>",
       text`

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,21 +25,30 @@ if (process.argv.length === 2) {
 
 program.name("lms").description("LM Studio CLI");
 
-program.addCommand(chat);
-program.addCommand(status);
-program.addCommand(server);
-program.addCommand(ls);
-program.addCommand(ps);
+program.commandsGroup("Manage Models:");
 program.addCommand(get);
+program.addCommand(importCmd);
+program.addCommand(ls);
+
+program.commandsGroup("Use Models:");
+program.addCommand(chat);
+program.addCommand(server);
 program.addCommand(load);
 program.addCommand(unload);
+program.addCommand(ps);
+
+program.commandsGroup("Develop & Publish Plugins:");
 program.addCommand(create);
-program.addCommand(log);
 program.addCommand(dev);
 program.addCommand(push);
+
+program.commandsGroup("Hub Login & Artifacts:");
 program.addCommand(clone);
 program.addCommand(login);
-program.addCommand(importCmd);
+
+program.commandsGroup("System Management:");
+program.addCommand(status);
+program.addCommand(log);
 program.addCommand(flags);
 program.addCommand(bootstrap);
 program.addCommand(version);

--- a/src/logLevel.ts
+++ b/src/logLevel.ts
@@ -7,6 +7,12 @@ const levels = ["debug", "info", "warn", "error", "none"] as const;
 
 /**
  * Adds log level options to a commander.js command
+ *
+ * This creates an Options Group. If other options are added without defining their own group,
+ * then they will be (likely erroneously) added to the this group.
+ * To avoid this, developers should either:
+ *   1. Define an options group before adding subsequent options
+ *   2. Add all options _before_ adding this group
  */
 export function addLogLevelOptions<
   Args extends any[],
@@ -14,6 +20,7 @@ export function addLogLevelOptions<
   GlobalOpts extends OptionValues,
 >(command: Command<Args, Opts, GlobalOpts>) {
   return command
+    .optionsGroup("Logging Options:")
     .addOption(new Option("--log-level <level>", "The level of logging to use").choices(levels))
     .option("--verbose", "Enable verbose logging")
     .option("--quiet", "Suppress all logging");


### PR DESCRIPTION
I added command groups to the top level command. I went for an "user action oriented" grouping. I find this is more readable than the big list of actions with no grouping.

I also added option groupings for Logging and Instance Option Groups. These options are appended to. many of our commands, so separating them out feels natural.

## Top-level help

After:
```txt
$ node publish/cli/dist/index.js -h
Usage: lms [options] [command]

LM Studio CLI

Options:
  -h, --help                         display help for command

Manage Models:
  get [options] [modelName]          Searching and downloading a model from
                                     online.
  import [options] <file-path>       Import a model file into LM Studio
  ls [options]                       List all downloaded models

Use Models:
  chat [options] [model]             Open an interactive chat with the currently
                                     loaded model.
  server                             Commands for managing the local server
  load [options] [path]              Load a model
  unload [options] [identifier]      Unload a model
  ps [options]                       List all loaded models

Develop & Publish Plugins:
  create [options] [scaffold]        Create a new project with scaffolding
  dev [options]                      Starts the development server for the
                                     plugin in the current folder.
  push [options]                     Uploads the plugin in the current folder to
                                     LM Studio Hub.

Hub Login & Artifacts:
  clone [options] <artifact> [path]  Clone an artifact from LM Studio Hub to a
                                     local folder.
  login [options]                    Authenticate with LM Studio

System Management:
  status [options]                   Prints the status of LM Studio
  log                                Log operations. Currently only supports
                                     streaming logs from LM Studio via `lms log
                                     stream`
  flags [options] [flag] [value]     Set or get experiment flags
  bootstrap [options]                Bootstrap the CLI
  version [options]                  Prints the version of the CLI

Commands:
  help [command]                     display help for command
```

Before:
```txt
$ node publish/cli/dist/index.js -h
Usage: lms [options] [command]

LM Studio CLI

Options:
  -h, --help                         display help for command

Commands:
  chat [options] [model]             Open an interactive chat with the currently
                                     loaded model.
  status [options]                   Prints the status of LM Studio
  server                             Commands for managing the local server
  ls [options]                       List all downloaded models
  ps [options]                       List all loaded models
  get [options] [modelName]          Searching and downloading a model from
                                     online.
  load [options] [path]              Load a model
  unload [options] [identifier]      Unload a model
  create [options] [scaffold]        Create a new project with scaffolding
  log                                Log operations. Currently only supports
                                     streaming logs from LM Studio via `lms log
                                     stream`
  dev [options]                      Starts the development server for the
                                     plugin in the current folder.
  push [options]                     Uploads the plugin in the current folder to
                                     LM Studio Hub.
  clone [options] <artifact> [path]  Clone an artifact from LM Studio Hub to a
                                     local folder.
  login [options]                    Authenticate with LM Studio
  import [options] <file-path>       Import a model file into LM Studio
  flags [options] [flag] [value]     Set or get experiment flags
  bootstrap [options]                Bootstrap the CLI
  version [options]                  Prints the version of the CLI
  help [command]                     display help for command
```

## `load` help
After:
```txt
$ node publish/cli/dist/index.js load -h
Usage: lms load [options] [path]

Load a model

Arguments:
  path                       The path of the model to load. If not provided, you
                             will be prompted to select one. If multiple models
                             match the path, you will also be prompted to select
                             one. If you don't wish to be prompted, please use
                             the --exact or the --yes flag.

Options:
  --ttl <seconds>            TTL: If provided, when the model is not used for
                             this number of seconds, it will be unloaded.
  --gpu <offload-ratio>      How much to offload to the GPU. If "off", GPU
                             offloading is disabled. If "max", all layers are
                             offloaded to GPU. If a number between 0 and 1, that
                             fraction of layers will be offloaded to the GPU. By
                             default, LM Studio will decide how much to offload
                             to the GPU.
  --context-length <length>  The number of tokens to consider as context when
                             generating text. If not provided, the default value
                             will be used.
  --exact                    Only load the model if the path provided matches
                             the model exactly. Fails if the path provided does
                             not match any model.
  --identifier <identifier>  The identifier to assign to the loaded model. The
                             identifier can be used to refer to the model in the
                             API.
  -y, --yes                  Suppress all confirmations and warnings. Useful for
                             scripting. If there are multiple models matching
                             the path, the first one will be loaded. Fails if
                             the path provided does not match any model.
  -h, --help                 display help for command

Instance Options:
  --host <host>              If you wish to connect to a remote LM Studio
                             instance, specify the host here. Note that, in this
                             case, lms will connect using client identifier
                             "lms-cli-remote-<random chars>", which will not be
                             a privileged client, and will restrict usage of
                             functionalities such as "lms push".
  --port <port>              The port where LM Studio can be reached. If not
                             provided and the host is set to "127.0.0.1"
                             (default), the last used port will be used;
                             otherwise, 1234 will be used.

Logging Options:
  --log-level <level>        The level of logging to use (choices: "debug",
                             "info", "warn", "error", "none")
  --verbose                  Enable verbose logging
  --quiet                    Suppress all logging
```

Before:
```txt
$ node publish/cli/dist/index.js load -h
Usage: lms load [options] [path]

Load a model

Arguments:
  path                       The path of the model to load. If not provided, you
                             will be prompted to select one. If multiple models
                             match the path, you will also be prompted to select
                             one. If you don't wish to be prompted, please use
                             the --exact or the --yes flag.

Options:
  --ttl <seconds>            TTL: If provided, when the model is not used for
                             this number of seconds, it will be unloaded.
  --gpu <offload-ratio>      How much to offload to the GPU. If "off", GPU
                             offloading is disabled. If "max", all layers are
                             offloaded to GPU. If a number between 0 and 1, that
                             fraction of layers will be offloaded to the GPU. By
                             default, LM Studio will decide how much to offload
                             to the GPU.
  --context-length <length>  The number of tokens to consider as context when
                             generating text. If not provided, the default value
                             will be used.
  --exact                    Only load the model if the path provided matches
                             the model exactly. Fails if the path provided does
                             not match any model.
  --identifier <identifier>  The identifier to assign to the loaded model. The
                             identifier can be used to refer to the model in the
                             API.
  -y, --yes                  Suppress all confirmations and warnings. Useful for
                             scripting. If there are multiple models matching
                             the path, the first one will be loaded. Fails if
                             the path provided does not match any model.
  --host <host>              If you wish to connect to a remote LM Studio
                             instance, specify the host here. Note that, in this
                             case, lms will connect using client identifier
                             "lms-cli-remote-<random chars>", which will not be
                             a privileged client, and will restrict usage of
                             functionalities such as "lms push".
  --port <port>              The port where LM Studio can be reached. If not
                             provided and the host is set to "127.0.0.1"
                             (default), the last used port will be used;
                             otherwise, 1234 will be used.
  --log-level <level>        The level of logging to use (choices: "debug",
                             "info", "warn", "error", "none")
  --verbose                  Enable verbose logging
  --quiet                    Suppress all logging
  -h, --help                 display help for command
```
