### PR TITLE
Fix server command behavior

### DIFF
--- a/src/subcommands/server.ts
+++ b/src/subcommands/server.ts
@@ -57,9 +57,9 @@ const start = addLogLevelOptions(
     `,
     ),
 ).action(async options => {
-  const { port, cors = false } = options;
-  const logger = createLogger(options);
-  const client = await createClient(logger, options);
+  const { port, cors = false, ...logArgs } = options;
+  const logger = createLogger(logArgs);
+  const client = await createClient(logger, logArgs);
   if (cors) {
     logger.warnText`
       CORS is enabled. This means any website you visit can use the LM Studio server.


### PR DESCRIPTION
## Overview

Before migration of `cmd-ts` to `commander.js`, we destructed the `options` to not include `port` in the `args` of `createClient` because that function does take in port and had conflicts with the internal behavior. 

This was reverted during the migration, so bringing it back in so `lms server start --port XYZ` works as expected. This is the only place we have an args conflict which will be fixed once `lms env` is introduced.  