### PR TITLE
feat(cli/unload): auto unload when only one model is loaded in. #121

### DIFF
--- a/src/subcommands/unload.ts
+++ b/src/subcommands/unload.ts
@@ -16,8 +16,9 @@ export const unload = addLogLevelOptions(
       .argument(
         "[identifier]",
         text`
-          The identifier of the model to unload. If not provided, you will be prompted to select a
-          model from a list interactively.
+          The identifier of the model to unload. If not provided and exactly one model is loaded, it
+          will be unloaded automatically. Otherwise, you will be prompted to select a model
+          interactively from a list.
         `,
       )
       .option("-a, --all", "Unload all models"),
@@ -92,6 +93,14 @@ export const unload = addLogLevelOptions(
     if (models.length === 0) {
       logger.error(`You don't have any models loaded. Use "lms load" to load a model.`);
       process.exit(1);
+    }
+    // If there is exactly one model loaded, unload it automatically without prompting.
+    if (models.length === 1) {
+      const model = models[0];
+      logger.debug(`Unloading "${model.identifier}"...`);
+      await client.llm.unload(model.identifier);
+      logger.info(`Model "${model.identifier}" unloaded.`);
+      return;
     }
     console.info();
     console.info(


### PR DESCRIPTION
### Summary
Small UX improvement: if there’s exactly one loaded model, `lms unload` skips the picker and unloads it right away. This aligns with the common single-model workflow and makes automation easier. 

### Why
Reduces friction, good for certain shell scripts. Addresses #121.

### Changes
- In unload command, check the count of loaded models:
  - 1 model -> call existing unload path directly and print the model identifier.
  - 0 models / >1 models -> existing behavior unchanged (interactive picker).
- Help text updated to include this pathing (Please review - I'm not certain if this behaviour is worth mentioning here).

### Screenshot
<img width="750" height="332" alt="image" src="https://github.com/user-attachments/assets/dab0378d-cd21-4aef-a853-ecc5703fba72" />

