### PR TITLE
Fix bug where lms cannot start server if missing http config file

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -78,7 +78,7 @@ export function addCreateClientOptions<
         "--port <port>",
         text`
           The port where LM Studio can be reached. If not provided and the host is set to "127.0.0.1"
-          (default), the last used port will be used; otherwise, 1234 will be used.
+          (default), the last used port will be used; otherwise, ${DEFAULT_SERVER_PORT} will be used.
         `,
       ).argParser(createRefinedNumberParser({ integer: true, min: 0, max: 65535 })),
     );

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -9,6 +9,9 @@ import { exists } from "./exists.js";
 import { appInstallLocationFilePath, lmsKey2Path } from "./lmstudioPaths.js";
 import { type LogLevelArgs } from "./logLevel.js";
 import { createRefinedNumberParser } from "./types/refinedNumber.js";
+
+export const DEFAULT_SERVER_PORT: number = 1234;
+
 /**
  * Checks if the HTTP server is running.
  */
@@ -244,7 +247,7 @@ export async function createClient(
   }
 
   if (port === undefined) {
-    port = 1234;
+    port = DEFAULT_SERVER_PORT;
   }
 
   logger.debug(`Connecting to server at ${host}:${port}`);

--- a/src/subcommands/server.ts
+++ b/src/subcommands/server.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "@commander-js/extra-typings";
 import { text, type SimpleLogger } from "@lmstudio/lms-common";
 import { readFile } from "fs/promises";
-import { checkHttpServer, createClient } from "../createClient.js";
+import { checkHttpServer, createClient, DEFAULT_SERVER_PORT } from "../createClient.js";
 import { exists } from "../exists.js";
 import { serverConfigPath } from "../lmstudioPaths.js";
 import { addLogLevelOptions, createLogger } from "../logLevel.js";
@@ -70,7 +70,7 @@ const start = addLogLevelOptions(
     `;
   }
 
-  const resolvedPort = port ?? (await getServerConfig(logger))?.port ?? 1234;
+  const resolvedPort = port ?? (await getServerConfig(logger))?.port ?? DEFAULT_SERVER_PORT;
   logger.debug(`Attempting to start the server on port ${resolvedPort}...`);
 
   await client.system.startHttpServer({

--- a/src/subcommands/status.ts
+++ b/src/subcommands/status.ts
@@ -1,7 +1,7 @@
 import { Command } from "@commander-js/extra-typings";
 import { text } from "@lmstudio/lms-common";
 import chalk from "chalk";
-import { addCreateClientOptions, checkHttpServer, createClient } from "../createClient.js";
+import { addCreateClientOptions, checkHttpServer, createClient, DEFAULT_SERVER_PORT } from "../createClient.js";
 import { formatSizeBytes1000 } from "../formatSizeBytes1000.js";
 import { addLogLevelOptions, createLogger } from "../logLevel.js";
 import { getServerConfig } from "./server.js";
@@ -19,13 +19,13 @@ export const status = addLogLevelOptions(
   if (port === undefined) {
     if (host === "127.0.0.1") {
       try {
-        port = (await getServerConfig(logger))?.port ?? 1234;
+        port = (await getServerConfig(logger))?.port ?? DEFAULT_SERVER_PORT;
       } catch (e) {
         logger.debug(`Failed to read last status`, e);
-        port = 1234;
+        port = DEFAULT_SERVER_PORT;
       }
     } else {
-      port = 1234;
+      port = DEFAULT_SERVER_PORT;
     }
   }
   const running = await checkHttpServer(logger, port, host);

--- a/src/subcommands/status.ts
+++ b/src/subcommands/status.ts
@@ -19,7 +19,7 @@ export const status = addLogLevelOptions(
   if (port === undefined) {
     if (host === "127.0.0.1") {
       try {
-        port = (await getServerConfig(logger)).port;
+        port = (await getServerConfig(logger))?.port ?? 1234;
       } catch (e) {
         logger.debug(`Failed to read last status`, e);
         port = 1234;


### PR DESCRIPTION
If `lms server start` is run when `.lmstudio/.internal/http-server-config.json` is missing, it will fail to start. Instead we should be okay with the file being missing, and start the server on the default port