### PR TITLE
Add -s for --source - lms log stream

### DIFF
--- a/src/subcommands/log.ts
+++ b/src/subcommands/log.ts
@@ -13,7 +13,7 @@ const stream = addLogLevelOptions(
       .option("--json", "Outputs in JSON format, separated by newline")
       .option("--stats", "Print prediction stats if available")
       .addOption(
-        new Option("--source <source>", "Source of logs: 'model' or 'server'")
+        new Option("-s, --source <source>", "Source of logs: 'model' or 'server'")
           .default("model")
           .choices(["model", "server"]),
       )


### PR DESCRIPTION
## Overview

Adds `-s` to `lms log stream` which is equivalent to `--source`


https://github.com/user-attachments/assets/3b1a7998-df71-4445-8269-bb174112984e

