### PR TITLE
Add `--estimate-only` to `lms load`

### DIFF
--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -1,7 +1,7 @@
 import { Command, InvalidArgumentError, Option } from "@commander-js/extra-typings";
 import { makeTitledPrettyError, type SimpleLogger, text } from "@lmstudio/lms-common";
 import { terminalSize } from "@lmstudio/lms-isomorphic";
-import { type LLMLlamaAccelerationOffloadRatio, type ModelInfo } from "@lmstudio/lms-shared-types";
+import { type ModelInfo } from "@lmstudio/lms-shared-types";
 import {
   type EstimatedResourcesUsage,
   type LLMLoadModelConfig,
@@ -101,7 +101,7 @@ export const load = addLogLevelOptions(
       .option(
         "--estimate-only",
         text`
-         Estimate the resources required to load the model, without loading it.
+          Calculate an estimate of the resources required to load the model. Does not load the model.
         `,
       ),
   ),


### PR DESCRIPTION
## Overview

Adds a new flag in `lms load` - `--estimate-only` which prints how an estimate of how much memory a model might need to load 


<img width="819" height="466" alt="image" src="https://github.com/user-attachments/assets/b2b854e0-16e1-4faf-9b28-ac721473e347" />
