### PR TITLE
Remove all bright colors and fix symbol for artifact download

### DIFF
--- a/src/architectureStylizations.ts
+++ b/src/architectureStylizations.ts
@@ -47,9 +47,9 @@ export class InfoLookup<TInnerKey, TLookupKey, TValue> {
   }
 }
 
-const llmColorer = chalk.cyanBright;
-const visionColorer = chalk.yellowBright;
-const embeddingColorer = chalk.blueBright;
+const llmColorer = chalk.cyan;
+const visionColorer = chalk.yellow;
+const embeddingColorer = chalk.blue;
 
 export const architectureInfoLookup = InfoLookup.createWithKeyMapper({
   fallback: (arch: string) => ({

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -163,9 +163,7 @@ export async function createClient(
     logger.error("Host should not include the protocol.");
     process.exit(1);
   } else if (host.includes(":")) {
-    logger.error(
-      `Host should not include the port number. Use ${chalk.yellowBright("--port")} instead.`,
-    );
+    logger.error(`Host should not include the port number. Use ${chalk.yellow("--port")} instead.`);
     process.exit(1);
   }
   let auth: LMStudioClientConstructorOpts;

--- a/src/ensureAuthenticated.ts
+++ b/src/ensureAuthenticated.ts
@@ -17,7 +17,7 @@ export async function ensureAuthenticated(
               "Authentication required",
               text`
                 This operation requires you to be authenticated. Inline authentication disabled due
-                to ${chalk.yellowBright("--yes")} flag. Please use ${chalk.yellowBright("lms auth")}
+                to ${chalk.yellow("--yes")} flag. Please use ${chalk.yellow("lms auth")}
                 to authenticate before running this command again.
               `,
               url,
@@ -26,7 +26,7 @@ export async function ensureAuthenticated(
         } else {
           logger.info("Authentication required. Please visit the following URL to authenticate:");
           logger.info();
-          logger.info(chalk.greenBright(`    ${url}`));
+          logger.info(chalk.green(`    ${url}`));
           logger.info();
         }
       },

--- a/src/formatSizeBytes1000.ts
+++ b/src/formatSizeBytes1000.ts
@@ -30,6 +30,6 @@ export function formatSizeBytesWithColor1000(sizeBytes: number) {
   } else if (sizeBytes < yellowThreshold) {
     return chalk.yellow(formatSizeBytes1000(sizeBytes));
   } else {
-    return chalk.redBright(formatSizeBytes1000(sizeBytes));
+    return chalk.red(formatSizeBytes1000(sizeBytes));
   }
 }

--- a/src/logLevel.ts
+++ b/src/logLevel.ts
@@ -56,9 +56,9 @@ export function getLogLevelMap({
   }
   if (numSpecified > 1) {
     throw makePrettyError(
-      chalk.redBright(text`
-        Only one of ${chalk.yellowBright("--logLevel")}, ${chalk.yellowBright("--verbose")}, or
-        ${chalk.yellowBright("--quiet")} can be specified.
+      chalk.red(text`
+        Only one of ${chalk.yellow("--logLevel")}, ${chalk.yellow("--verbose")}, or
+        ${chalk.yellow("--quiet")} can be specified.
       `),
     );
   }

--- a/src/subcommands/create.ts
+++ b/src/subcommands/create.ts
@@ -101,9 +101,9 @@ export const create = addLogLevelOptions(
 
   console.info(
     text`
-        ${chalk.greenBright.underline(" Welcome to LM Studio Interactive Project Creator ")}
+        ${chalk.green.underline(" Welcome to LM Studio Interactive Project Creator ")}
 
-        ${chalk.white("Select a scaffold to use from the list below.")}
+       Select a scaffold to use from the list below.
       `,
   );
 
@@ -149,7 +149,7 @@ async function selectScaffold(
   const { selected } = await prompt({
     type: "autocomplete",
     name: "selected",
-    message: chalk.greenBright("Select a scaffold to use") + chalk.gray(" |"),
+    message: chalk.green("Select a scaffold to use") + chalk.gray(" |"),
     initialSearch,
     loop: false,
     pageSize: terminalSize().rows - leaveEmptyLines - 3,
@@ -358,7 +358,7 @@ async function createWithScaffold(logger: SimpleLogger, scaffold: Scaffold) {
       .replaceAll("</hl>", "\x1b[39m");
     switch (type) {
       case "title":
-        motdLines.push(chalk.greenBright(`  ${message}  `));
+        motdLines.push(chalk.green(`  ${message}  `));
         break;
       case "regular":
         motdLines.push(message);
@@ -368,7 +368,7 @@ async function createWithScaffold(logger: SimpleLogger, scaffold: Scaffold) {
           message
             .trim()
             .split("\n")
-            .map(msg => "    " + chalk.yellowBright(msg))
+            .map(msg => "    " + chalk.yellow(msg))
             .join("\n"),
         );
         break;

--- a/src/subcommands/get.ts
+++ b/src/subcommands/get.ts
@@ -181,7 +181,7 @@ export const get = addLogLevelOptions(
   }
 
   if (searchTerm !== undefined) {
-    logger.info("Searching for models with the term", chalk.yellowBright(searchTerm));
+    logger.info("Searching for models with the term", chalk.yellow(searchTerm));
   }
 
   const opts = {
@@ -354,12 +354,12 @@ export const get = addLogLevelOptions(
     if (alreadyExisted) {
       logger.infoText`
         You already have this model. You can load it with:
-        ${chalk.yellowBright("\n\n    lms load " + defaultIdentifier)}
+        ${chalk.yellow("\n\n    lms load " + defaultIdentifier)}
       `;
     } else {
       logger.infoText`
         Download completed. You can load the model with:
-        ${chalk.yellowBright("\n\n    lms load " + defaultIdentifier)}
+        ${chalk.yellow("\n\n    lms load " + defaultIdentifier)}
       `;
     }
     logger.info();
@@ -403,7 +403,7 @@ async function askToChooseModel(
             name += "[Staff Pick] ";
           }
           if (model.isExactMatch()) {
-            name += chalk.yellowBright("[Exact Match] ");
+            name += chalk.yellow("[Exact Match] ");
           }
           name += option.string;
           return {
@@ -430,32 +430,32 @@ async function askToChooseDownloadOption(
       type: "list",
       name: "option",
       default: defaultIndex,
-      message: chalk.greenBright("Select an option to download"),
+      message: chalk.green("Select an option to download"),
       loop: false,
       pageSize: terminalSize().rows - 4 - additionalRowsToReserve,
       choices: downloadOptions.map(option => {
         let name = "";
         if (option.quantization !== undefined && option.quantization !== "") {
-          name += chalk.whiteBright(`${option.quantization} `.padEnd(9));
+          name += `${option.quantization} `.padEnd(9);
         }
-        name += chalk.whiteBright(`${formatSizeBytes1000(option.sizeBytes)} `.padStart(11));
+        name += `${formatSizeBytes1000(option.sizeBytes)} `.padStart(11);
         name += chalk.gray(option.name) + " ";
         switch (option.fitEstimation) {
           case "willNotFit":
-            name += chalk.redBright("[Likely too large for this machine]");
+            name += chalk.red("[Likely too large for this machine]");
             break;
           case "fitWithoutGPU":
-            name += chalk.greenBright("[Likely fit]");
+            name += chalk.green("[Likely fit]");
             break;
           case "partialGPUOffload":
-            name += chalk.yellowBright("[Partial GPU offload possible]");
+            name += chalk.yellow("[Partial GPU offload possible]");
             break;
           case "fullGPUOffload":
-            name += chalk.greenBright("[Full GPU offload possible]");
+            name += chalk.green("[Full GPU offload possible]");
             break;
         }
         if (option.isRecommended()) {
-          name += " " + chalk.greenBright(" Recommended ");
+          name += " " + chalk.green(" Recommended ");
         }
         return {
           name,
@@ -497,7 +497,7 @@ function modelToString(model: ArtifactDownloadPlanModelInfo) {
   return result;
 }
 
-const toDownloadText = chalk.yellowBright("🡇 To download:");
+const toDownloadText = chalk.yellow("↓ To download:");
 
 async function artifactDownloadPlanToString(
   plan: ArtifactDownloadPlan,
@@ -509,7 +509,7 @@ async function artifactDownloadPlanToString(
 ) {
   const node = plan.nodes[currentNodeIndex];
   if (node === undefined) {
-    lines.push(chalk.redBright("<Invalid: node not found>"));
+    lines.push(chalk.red("<Invalid: node not found>"));
     return;
   }
   const nodeType = node.type;
@@ -521,21 +521,21 @@ async function artifactDownloadPlanToString(
       const artifactName = `${node.owner}/${node.name}`;
       switch (nodeState) {
         case "pending": {
-          message = `⧗ ${chalk.white(artifactName)} ${chalk.white("- Pending...")}`;
+          message = `⧗ ${artifactName} - Pending...`;
           break;
         }
         case "fetching": {
-          message = `${spinnerFrames[(spinnerFrame + currentNodeIndex) % spinnerFrames.length]} ${chalk.whiteBright(artifactName)} ${chalk.gray("- Resolving...")}`;
+          message = `${spinnerFrames[(spinnerFrame + currentNodeIndex) % spinnerFrames.length]} ${artifactName} ${chalk.gray("- Resolving...")}`;
           break;
         }
         case "satisfied": {
-          message = `${chalk.greenBright("✓ Satisfied")} ${chalk.whiteBright(artifactName)}`;
+          message = `${chalk.green("✓ Satisfied")} ${artifactName}`;
           break;
         }
         case "completed": {
           message =
             `${toDownloadText} ` +
-            `${node.artifactType} ${chalk.whiteBright(artifactName)} - ` +
+            `${node.artifactType} ${artifactName} - ` +
             `${formatSizeBytesWithColor1000(node.sizeBytes ?? 0)}`;
           break;
         }
@@ -565,7 +565,7 @@ async function artifactDownloadPlanToString(
       const nodeState = node.state;
       switch (nodeState) {
         case "pending": {
-          message = `⧗ ${chalk.white("Concrete Model")} ${chalk.white("- Pending...")}`;
+          message = `⧗ Concrete Model - Pending...`;
           break;
         }
         case "fetching": {
@@ -575,20 +575,20 @@ async function artifactDownloadPlanToString(
         case "satisfied": {
           const owned = node.alreadyOwned;
           if (owned === undefined) {
-            message = `${chalk.greenBright("✓ Satisfied")} ${chalk.whiteBright("Unknown")}`;
+            message = `${chalk.green("✓ Satisfied")} Unknown`;
           } else {
-            message = `${chalk.greenBright("✓ Satisfied")} ${chalk.whiteBright(modelToString(owned))}`;
+            message = `${chalk.green("✓ Satisfied")} ${modelToString(owned)}`;
           }
           break;
         }
         case "completed": {
           const selected = node.selected;
           if (selected === undefined) {
-            message = `${toDownloadText} ${chalk.whiteBright("Unknown")}`;
+            message = `${toDownloadText} Unknown`;
           } else {
             message =
               `${toDownloadText} ` +
-              `${chalk.whiteBright(modelToString(selected))} - ` +
+              `${modelToString(selected)} - ` +
               `${formatSizeBytesWithColor1000(selected.sizeBytes)}`;
           }
           break;
@@ -644,13 +644,13 @@ export async function downloadArtifact(
       if (downloadPlan.downloadSizeBytes !== 0) {
         if (yes) {
           lines.push(
-            chalk.yellowBright(
+            chalk.yellow(
               `Resolution completed. Downloading ${formatSizeBytes1000(downloadPlan.downloadSizeBytes)}...`,
             ),
           );
         } else {
           lines.push(
-            chalk.yellowBright(
+            chalk.yellow(
               `About to download ${formatSizeBytes1000(downloadPlan.downloadSizeBytes)}.`,
             ),
           );

--- a/src/subcommands/importCmd.ts
+++ b/src/subcommands/importCmd.ts
@@ -241,7 +241,7 @@ async function validateModelNameOrWarn(
       logger.warn(`Model files usually have extensions: ${modelExtensions.join(", ")}`);
     } else {
       process.stderr.write(text`
-        ${"\n"}${chalk.yellowBright.underline(" File does not look like a model file ")}
+        ${"\n"}${chalk.yellow.underline(" File does not look like a model file ")}
 
         This file does not look like a model file:
 
@@ -253,7 +253,7 @@ async function validateModelNameOrWarn(
         {
           type: "confirm",
           name: "cont",
-          message: chalk.greenBright("Do you wish to continue? (Not recommended)"),
+          message: chalk.green("Do you wish to continue? (Not recommended)"),
           default: false,
         },
       ]);
@@ -383,20 +383,20 @@ async function warnAboutMove(
   }
   logger.debug("Asking user to confirm moving the file");
   process.stderr.write(text`
-    ${"\n"}${chalk.greenBright.underline(" Importing model file into LM Studio ")}
+    ${"\n"}${chalk.green.underline(" Importing model file into LM Studio ")}
 
-    By default, ${chalk.yellow("lms import")} will ${chalk.cyanBright("move")} the file to LM
+    By default, ${chalk.yellow("lms import")} will ${chalk.cyan("move")} the file to LM
     Studio's models folder:
 
         ${chalk.gray(modelsFolderPath)}
 
-    If you want to ${chalk.cyanBright("copy")} the file instead, use the ${chalk.yellow("--copy")}
+    If you want to ${chalk.cyan("copy")} the file instead, use the ${chalk.yellow("--copy")}
     flag.
 
-    If you want to create a ${chalk.cyanBright("symbolic link")} instead, use the
+    If you want to create a ${chalk.cyan("symbolic link")} instead, use the
     ${chalk.yellow("--symbolic-link")} flag.
 
-    If you want to create a ${chalk.cyanBright("hard link")} instead, use the
+    If you want to create a ${chalk.cyan("hard link")} instead, use the
     ${chalk.yellow("--hard-link")} flag.
 
     This message will only show up once. You can always look up the usage via the
@@ -406,7 +406,7 @@ async function warnAboutMove(
     {
       type: "confirm",
       name: "cont",
-      message: chalk.greenBright("Do you wish to continue?"),
+      message: chalk.green("Do you wish to continue?"),
       default: true,
     },
   ]);
@@ -500,7 +500,7 @@ async function resolveUserRepo(
     await pm({
       type: "list",
       name: "value",
-      message: chalk.greenBright("Choose categorization option"),
+      message: chalk.green("Choose categorization option"),
       choices: [
         {
           name: text`
@@ -551,14 +551,14 @@ async function resolveByAskUserRepo(
     {
       type: "input",
       name: "user",
-      message: chalk.greenBright("Who is the creator of the model?"),
+      message: chalk.green("Who is the creator of the model?"),
       default: getDefaultUserName(),
       validate: input => isValidFolderName("User", input),
     },
     {
       type: "input",
       name: "repo",
-      message: chalk.greenBright("What is the model name?"),
+      message: chalk.green("What is the model name?"),
       default: autoNameRepo(basename(path)),
       validate: input => isValidFolderName("Repository", input),
     },
@@ -595,7 +595,7 @@ async function resolveByHuggingFaceInteractive(
   const { selected } = await pm({
     type: "autocomplete",
     name: "selected",
-    message: chalk.greenBright("Please select the correct one") + chalk.gray(" |"),
+    message: chalk.green("Please select the correct one") + chalk.gray(" |"),
     loop: false,
     pageSize: terminalSize().rows - 3,
     emptyText: "No model matched the filter",

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -13,9 +13,9 @@ function loadedCheck(count: number) {
   if (count === 0) {
     return "";
   } else if (count === 1) {
-    return chalk.greenBright("✓ LOADED");
+    return chalk.green("✓ LOADED");
   } else {
-    return chalk.greenBright(`✓ LOADED (${count})`);
+    return chalk.green(`✓ LOADED (${count})`);
   }
 }
 
@@ -122,12 +122,10 @@ export const ls = addCreateClientOptions(
 
   if (afterFilteringModelsCount === 0) {
     if (originalModelsCount === 0) {
-      console.info(chalk.redBright("You have not downloaded any models yet."));
+      console.info(chalk.red("You have not downloaded any models yet."));
     } else {
       console.info(
-        chalk.redBright(
-          `You have ${originalModelsCount} models, but none of them match the filter.`,
-        ),
+        chalk.red(`You have ${originalModelsCount} models, but none of them match the filter.`),
       );
     }
     return;

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -148,8 +148,8 @@ export const load = addLogLevelOptions(
         makeTitledPrettyError(
           "Path not provided",
           text`
-            The parameter ${chalk.cyanBright("[path]")} is required when using the
-            ${chalk.yellowBright("--exact")} flag.
+            The parameter ${chalk.cyan("[path]")} is required when using the
+            ${chalk.yellow("--exact")} flag.
           `,
         ).message,
       );
@@ -166,13 +166,13 @@ export const load = addLogLevelOptions(
         makeTitledPrettyError(
           "Model not found",
           text`
-            No model found with path being exactly "${chalk.yellowBright(path)}".
+            No model found with path being exactly "${chalk.yellow(path)}".
 
-            To disable exact matching, remove the ${chalk.yellowBright("--exact")} flag.
+            To disable exact matching, remove the ${chalk.yellow("--exact")} flag.
 
             To see a list of all downloaded models, run:
 
-                ${chalk.yellowBright("lms ls")}
+                ${chalk.yellow("lms ls")}
 
             Note, you need to provide the full model path. For example:
 
@@ -207,13 +207,13 @@ export const load = addLogLevelOptions(
         makeTitledPrettyError(
           "Model not found",
           text`
-            No model found that matches path "${chalk.yellowBright(path)}".
+            No model found that matches path "${chalk.yellow(path)}".
 
             To see a list of all downloaded models, run:
 
-                ${chalk.yellowBright("lms ls")}
+                ${chalk.yellow("lms ls")}
 
-            To select a model interactively, remove the ${chalk.yellowBright("--yes")} flag:
+            To select a model interactively, remove the ${chalk.yellow("--yes")} flag:
 
                 lms load
           `,
@@ -233,8 +233,8 @@ export const load = addLogLevelOptions(
       model = await selectModelToLoad(models, modelPaths, "", 4, lastLoadedMap);
     } else if (initialFilteredModels.length === 0) {
       console.info(
-        chalk.redBright(text`
-          ! Cannot find a model matching the provided path (${chalk.yellowBright(path)}). Please
+        chalk.red(text`
+          ! Cannot find a model matching the provided path (${chalk.yellow(path)}). Please
           select one from the list below.
         `),
       );
@@ -297,7 +297,7 @@ async function selectModelToLoad(
   const { selected } = await prompt({
     type: "autocomplete",
     name: "selected",
-    message: chalk.greenBright("Select a model to load") + chalk.gray(" |"),
+    message: chalk.green("Select a model to load") + chalk.gray(" |"),
     initialSearch,
     loop: false,
     pageSize: terminalSize().rows - leaveEmptyLines,
@@ -312,7 +312,7 @@ async function selectModelToLoad(
         const displayName =
           option.string + " " + chalk.gray(`(${formatSizeBytes1000(model.sizeBytes)})`);
         // if (lastLoadedMap.has(model.path)) {
-        //   displayName = chalk.yellowBright("[Recent] ") + displayName;
+        //   displayName = chalk.yellow("[Recent] ") + displayName;
         // }
         return {
           value: model,
@@ -366,11 +366,11 @@ async function loadModel(
   `);
   const info = await llmModel.getModelInfo();
   logger.info(text`
-    To use the model in the API/SDK, use the identifier "${chalk.greenBright(info!.identifier)}".
+    To use the model in the API/SDK, use the identifier "${chalk.green(info!.identifier)}".
   `);
   if (identifier === undefined) {
     logger.info(text`
-      To set a custom identifier, use the ${chalk.yellowBright("--identifier <identifier>")} option.
+      To set a custom identifier, use the ${chalk.yellow("--identifier <identifier>")} option.
     `);
   }
 }
@@ -382,7 +382,7 @@ function printEstimatedResourceUsage(
   estimate: EstimatedResourcesUsage,
   logger: SimpleLogger,
 ) {
-  const colorFunc = estimate.passesGuardrails === true ? chalk.greenBright : chalk.yellow;
+  const colorFunc = estimate.passesGuardrails === true ? chalk.green : chalk.yellow;
   logger.info(`Model: ${model.path}`);
   if (contextLength !== undefined) {
     logger.info(`Context Length: ${contextLength.toLocaleString()}`);

--- a/src/subcommands/log.ts
+++ b/src/subcommands/log.ts
@@ -110,8 +110,8 @@ function printFormattedLog(log: DiagnosticsLogEvent, stats: boolean): void {
     return;
   }
 
-  console.log("timestamp: " + chalk.greenBright(new Date(log.timestamp).toLocaleString()));
-  console.log("type: " + chalk.greenBright(log.data.type));
+  console.log("timestamp: " + chalk.green(new Date(log.timestamp).toLocaleString()));
+  console.log("type: " + chalk.green(log.data.type));
   printLlmPredictionLogEvent(log.data, stats);
   console.log();
   console.log();
@@ -119,19 +119,19 @@ function printFormattedLog(log: DiagnosticsLogEvent, stats: boolean): void {
 
 function printLlmPredictionLogEvent(data: DiagnosticsLogEventData, stats: boolean) {
   if (data.type === "server.log") return;
-  console.log("modelIdentifier: " + chalk.greenBright(data.modelIdentifier));
+  console.log("modelIdentifier: " + chalk.green(data.modelIdentifier));
   if (data.type === "llm.prediction.input") {
-    console.log("modelPath: " + chalk.greenBright(data.modelPath));
+    console.log("modelPath: " + chalk.green(data.modelPath));
     console.log("input:");
-    console.log(chalk.greenBright(data.input));
+    console.log(chalk.green(data.input));
   }
   if (data.type === "llm.prediction.output") {
     console.log("output:");
-    console.log(chalk.greenBright(data.output));
+    console.log(chalk.green(data.output));
     if (stats === true) {
       if (data.stats !== undefined) {
         Object.entries(data.stats).forEach(([key, value]) => {
-          console.log(`${key}: ${chalk.greenBright(value)}`);
+          console.log(`${key}: ${chalk.green(value)}`);
         });
       } else {
         console.log("No stats available");

--- a/src/subcommands/login.ts
+++ b/src/subcommands/login.ts
@@ -79,7 +79,7 @@ export const login = addLogLevelOptions(
       }
 
       logger.info();
-      logger.info(chalk.greenBright(`    ${url}`));
+      logger.info(chalk.green(`    ${url}`));
       logger.info();
     },
   });

--- a/src/subcommands/status.ts
+++ b/src/subcommands/status.ts
@@ -1,7 +1,12 @@
 import { Command } from "@commander-js/extra-typings";
 import { text } from "@lmstudio/lms-common";
 import chalk from "chalk";
-import { addCreateClientOptions, checkHttpServer, createClient, DEFAULT_SERVER_PORT } from "../createClient.js";
+import {
+  addCreateClientOptions,
+  checkHttpServer,
+  createClient,
+  DEFAULT_SERVER_PORT,
+} from "../createClient.js";
 import { formatSizeBytes1000 } from "../formatSizeBytes1000.js";
 import { addLogLevelOptions, createLogger } from "../logLevel.js";
 import { getServerConfig } from "./server.js";
@@ -32,7 +37,7 @@ export const status = addLogLevelOptions(
   let content = "";
   if (running) {
     content += text`
-      Server: ${chalk.greenBright("ON")} (port: ${port})
+      Server: ${chalk.green("ON")} (port: ${port})
     `;
     content += "\n\n";
 
@@ -56,7 +61,7 @@ export const status = addLogLevelOptions(
     }
   } else {
     content += text`
-      Server: ${chalk.redBright(" OFF ")}
+      Server: ${chalk.red(" OFF ")}
 
       ${chalk.gray("(i) To start the server, run the following command:")}
 

--- a/src/subcommands/unload.ts
+++ b/src/subcommands/unload.ts
@@ -33,8 +33,8 @@ export const unload = addLogLevelOptions(
       makeTitledPrettyError(
         "Invalid Usage",
         text`
-          You cannot provide ${chalk.cyanBright("[path]")} when the flag
-          ${chalk.yellowBright("--all")} is set.
+          You cannot provide ${chalk.cyan("[path]")} when the flag
+          ${chalk.yellow("--all")} is set.
         `,
       ).message,
     );
@@ -76,11 +76,11 @@ export const unload = addLogLevelOptions(
         makeTitledPrettyError(
           "Model Not Found",
           text`
-            Cannot find a model with the identifier "${chalk.yellowBright(identifier)}".
+            Cannot find a model with the identifier "${chalk.yellow(identifier)}".
 
             To see a list of loaded models, run:
 
-                ${chalk.yellowBright("lms ps")}
+                ${chalk.yellow("lms ps")}
           `,
         ).message,
       );
@@ -113,7 +113,7 @@ export const unload = addLogLevelOptions(
     const { selected } = await prompt({
       type: "autocomplete",
       name: "selected",
-      message: chalk.greenBright("Select a model to unload") + chalk.gray(" |"),
+      message: chalk.green("Select a model to unload") + chalk.gray(" |"),
       initialSearch: "",
       loop: false,
       pageSize: terminalSize().rows - 5,


### PR DESCRIPTION
## Overview

This tweaks colors of our CLI tool to be better to read in light themes and avoid using `chalk.white` because iTerm2 cannot invert it. Also fixes the download arrow character bug in artifact download


### Bug in question regarding chalk.white
<img width="1060" height="248" alt="image" src="https://github.com/user-attachments/assets/83005fd8-2b8d-489a-929f-ba47f730c312" />


### Before

<img width="493" height="130" alt="Screenshot 2025-09-23 at 5 34 31 PM" src="https://github.com/user-attachments/assets/031ee16f-c626-4cdd-8af3-b93d1383e206" />
<img width="516" height="108" alt="Screenshot 2025-09-23 at 5 35 37 PM" src="https://github.com/user-attachments/assets/f9f8c4e0-83a0-4e05-96c9-7a8f4c0e7fac" />


### After

<img width="508" height="155" alt="image" src="https://github.com/user-attachments/assets/84418545-f467-4866-991d-c7a0aaad19b9" />
<img width="490" height="162" alt="image" src="https://github.com/user-attachments/assets/2e4d5f0e-e85f-41c8-88a3-b5142d6759bf" />

