### PR TITLE
Add progress bar in `lms chat <model_name>`

### DIFF
--- a/src/subcommands/chat/index.ts
+++ b/src/subcommands/chat/index.ts
@@ -399,33 +399,8 @@ export const chat = addLogLevelOptions(
       }
       if (!selectedModel.isDownloaded) {
         if (selectedModel.inModelCatalog) {
-          const beforeKeys = new Set(
-            (await client.system.listDownloadedModels()).map(m => m.modelKey),
-          );
           const [owner, name] = selectedModel.name.split("/");
           await downloadArtifact(client, logger, owner, name, yes ?? false);
-          // Wait for model indexing to complete after download
-          await new Promise<void>(resolve => {
-            const interval = setInterval(async () => {
-              const afterKeys = new Set(
-                (await client.system.listDownloadedModels()).map(m => m.modelKey),
-              );
-
-              // If the sets differ in size or membership, we're done
-              if (
-                afterKeys.size !== beforeKeys.size ||
-                [...afterKeys].some(k => !beforeKeys.has(k))
-              ) {
-                clearInterval(interval);
-                resolve();
-              }
-            }, 500);
-
-            setTimeout(() => {
-              clearInterval(interval);
-              resolve();
-            }, 30_000); // safety timeout
-          });
         } else {
           // It is not a model from the catalog, so must be a direct model which is not downloaded,
           // unexpected path as only cataloged models are offered to download


### PR DESCRIPTION
## Overview
Introduces the progress bar when a model is specified in `lms chat` 

<img width="757" height="146" alt="image" src="https://github.com/user-attachments/assets/52e8dc6e-159c-49a2-97d9-395c4f923b28" />



OLD: 
~While using `lms chat`, if we download a model and 'quickly' try to load it (programmatically) , in a few cases this can error out and give warnings because app did not pick up the new model.~

~To solve this, we had a hardcoded timeout in place. This is not reliable and this PR switches it's logic to see if after downloading the model, if the set of model keys changed that can be concluded to the fact that app has detected the new model and should be good to load.~

