### PR TITLE
Add `daemon status` command

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -102,7 +102,7 @@ async function isLocalServerAtPortLMStudioServerOrThrow(port: number) {
   return port;
 }
 
-async function tryFindLocalAPIServer(): Promise<number | null> {
+export async function tryFindLocalAPIServer(): Promise<number | null> {
   return await Promise.any(apiServerPorts.map(isLocalServerAtPortLMStudioServerOrThrow)).then(
     port => port,
     () => null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ program.addCommand(push);
 
 program.commandsGroup("System Management:");
 program.addCommand(bootstrap);
-program.addCommand(daemon);
+program.addCommand(daemon, { hidden: true });
 program.addCommand(flags);
 program.addCommand(log);
 program.addCommand(runtime);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { bootstrap } from "./subcommands/bootstrap.js";
 import { chat } from "./subcommands/chat/index.js";
 import { clone } from "./subcommands/clone.js";
 import { create } from "./subcommands/create.js";
+import { daemon } from "./subcommands/daemon.js";
 import { dev } from "./subcommands/dev/index.js";
 import { flags } from "./subcommands/flags.js";
 import { get } from "./subcommands/get.js";
@@ -65,6 +66,7 @@ program.addCommand(push);
 
 program.commandsGroup("System Management:");
 program.addCommand(bootstrap);
+program.addCommand(daemon);
 program.addCommand(flags);
 program.addCommand(log);
 program.addCommand(runtime);

--- a/src/subcommands/daemon.ts
+++ b/src/subcommands/daemon.ts
@@ -1,0 +1,59 @@
+import { Command } from "@commander-js/extra-typings";
+import { LMStudioClient } from "@lmstudio/sdk";
+import { tryFindLocalAPIServer } from "../createClient.js";
+import { addLogLevelOptions, createLogger } from "../logLevel.js";
+
+const status = addLogLevelOptions(
+  new Command()
+    .name("status")
+    .description("Check the status of the LM Studio daemon")
+    .option("--json", "Output status in JSON format"),
+).action(async options => {
+  const logger = createLogger(options);
+  const useJson = options.json ?? false;
+
+  // First, check if the daemon is running without waking it up
+  const port = await tryFindLocalAPIServer();
+
+  if (port === null) {
+    // Daemon is not running
+    if (useJson) {
+      console.log(JSON.stringify({ status: "not-running" }));
+    } else {
+      logger.info("LM Studio is not running");
+    }
+    return;
+  }
+
+  // Daemon is running, now get detailed info
+  try {
+    const client = new LMStudioClient({
+      baseUrl: `ws://127.0.0.1:${port}`,
+      logger,
+    });
+
+    const info = await client.system.getInfo();
+
+    // Sanity check the PID
+    if (!Number.isInteger(info.pid) || info.pid <= 0) {
+      logger.error("Received invalid PID from server");
+      process.exit(1);
+    }
+
+    // Output results
+    if (useJson) {
+      console.log(JSON.stringify({ status: "running", pid: info.pid }));
+    } else {
+      const processName = info.isDaemon ? "llmster" : "LM Studio";
+      logger.info(`${processName} is running (PID: ${info.pid})`);
+    }
+  } catch (error) {
+    logger.error("Failed to get daemon info:", error);
+    process.exit(1);
+  }
+});
+
+export const daemon = new Command()
+  .name("daemon")
+  .description("Commands for managing the LM Studio daemon")
+  .addCommand(status);


### PR DESCRIPTION
Add `lms daemon status`.

Hide this command from the help menu for now.

Tested to make sure that this works, here is some of the output:
```
$ lmsd daemon status       
LM Studio is running (PID: 5331)
$ lmsd daemon status --json
{"status":"running","pid":5331}
$ lmsd daemon status --json
{"status":"not-running"}
$ lmsd daemon status       
LM Studio is not running
```