### PR TITLE
Fix `lms runtime get -h` options grouping

### DIFF
--- a/src/subcommands/runtime/get.ts
+++ b/src/subcommands/runtime/get.ts
@@ -207,7 +207,6 @@ export const get = addLogLevelOptions(
         "Query runtime extensions. Examples: 'llama.cpp', 'llama.cpp:cuda', 'llama.cpp@1.2.3'",
       )
       .option("-l, --list", "List runtime extensions without downloading")
-      .option("-y, --yes", "Automatically pick the first result when multiple matches are found")
       .option(
         "--allow-incompatible",
         "Include runtime extensions that are incompatible with your system",
@@ -218,6 +217,7 @@ export const get = addLogLevelOptions(
           "Override the runtime extension channel to query from",
         ).choices(["stable", "beta"]),
       )
+      .option("-y, --yes", "Automatically pick the first result when multiple matches are found")
       .action(async function (queryArgument: string | undefined, commandOptions) {
         const parentOptions = this.parent?.opts() ?? {};
         const logger = createLogger(parentOptions);


### PR DESCRIPTION
```txt
Usage: lms runtime get [options] [query]

Download or list runtime extensions.

Arguments:
  query                 Query runtime extensions. Examples: 'llama.cpp',
                        'llama.cpp:cuda', 'llama.cpp@1.2.3'

Options:
  -l, --list            List runtime extensions without downloading
  --allow-incompatible  Include runtime extensions that are incompatible with your
                        system
  --channel <channel>   Override the runtime extension channel to query from
                        (choices: "stable", "beta")
  -y, --yes             Automatically pick the first result when multiple matches are
                        found
  -h, --help            display help for command

Instance Options:
  --host <host>         If you wish to connect to a remote LM Studio instance,
                        specify the host here. Note that, in this case, lms will
                        connect using client identifier "lms-cli-remote-<random
                        chars>", which will not be a privileged client, and will
                        restrict usage of functionalities such as "lms push".
  --port <port>         The port where LM Studio can be reached. If not provided and
                        the host is set to "127.0.0.1" (default), the last used port
                        will be used; otherwise, 1234 will be used.

Logging Options:
  --log-level <level>   The level of logging to use (choices: "debug", "info",
                        "warn", "error", "none")
  --quiet               Suppress all logging
  --verbose             Enable verbose logging
```