### PR TITLE
Fix `lms runtime update -h` options grouping

### DIFF
--- a/src/subcommands/runtime/update.ts
+++ b/src/subcommands/runtime/update.ts
@@ -223,36 +223,38 @@ async function runtimeUpdateAction(
 
 export const update = addLogLevelOptions(
   addCreateClientOptions(
-    new Command().name("update").description("Update installed runtime extensions."),
-  )
-    .argument(
-      "[query]",
-      "Query runtime extensions. Examples: 'llama.cpp', 'llama.cpp:cuda', 'llama.cpp@1.2.3'",
-    )
-    .option("-a, --all", "Update all installed runtime extensions")
-    .option(
-      "--allow-incompatible",
-      "Include runtime extensions that are incompatible with your system",
-    )
-    .addOption(
-      new Option(
-        "--channel <channel>",
-        "Override the runtime extension channel to query from",
-      ).choices(["stable", "beta"]),
-    )
-    .option("--dry-run", "Show extensions that would be updated without performing downloads")
-    .option("-y, --yes", "Skip confirmation prompts")
-    .action(async function (queryArgument: string | undefined, options) {
-      const parentOptions = this.parent?.opts() ?? {};
-      const logger = createLogger(parentOptions);
-      const client = await createClient(logger, parentOptions);
+    new Command()
+      .name("update")
+      .description("Update installed runtime extensions.")
+      .argument(
+        "[query]",
+        "Query runtime extensions. Examples: 'llama.cpp', 'llama.cpp:cuda', 'llama.cpp@1.2.3'",
+      )
+      .option("-a, --all", "Update all installed runtime extensions")
+      .option(
+        "--allow-incompatible",
+        "Include runtime extensions that are incompatible with your system",
+      )
+      .addOption(
+        new Option(
+          "--channel <channel>",
+          "Override the runtime extension channel to query from",
+        ).choices(["stable", "beta"]),
+      )
+      .option("--dry-run", "Show extensions that would be updated without performing downloads")
+      .option("-y, --yes", "Skip confirmation prompts")
+      .action(async function (queryArgument: string | undefined, options) {
+        const parentOptions = this.parent?.opts() ?? {};
+        const logger = createLogger(parentOptions);
+        const client = await createClient(logger, parentOptions);
 
-      await runtimeUpdateAction(logger, client, queryArgument, {
-        all: options.all ?? false,
-        allowIncompatible: options.allowIncompatible ?? false,
-        channel: options.channel,
-        dryRun: options.dryRun ?? false,
-        yes: options.yes ?? false,
-      });
-    }),
+        await runtimeUpdateAction(logger, client, queryArgument, {
+          all: options.all ?? false,
+          allowIncompatible: options.allowIncompatible ?? false,
+          channel: options.channel,
+          dryRun: options.dryRun ?? false,
+          yes: options.yes ?? false,
+        });
+      }),
+  ),
 );


### PR DESCRIPTION
```
Usage: lms runtime update [options] [query]

Update installed runtime extensions.

Arguments:
  query                 Query runtime extensions. Examples: 'llama.cpp',
                        'llama.cpp:cuda', 'llama.cpp@1.2.3'

Options:
  -a, --all             Update all installed runtime extensions
  --allow-incompatible  Include runtime extensions that are incompatible with your
                        system
  --channel <channel>   Override the runtime extension channel to query from
                        (choices: "stable", "beta")
  --dry-run             Show extensions that would be updated without performing
                        downloads
  -y, --yes             Skip confirmation prompts
  -h, --help            display help for command

Instance Options:
  --host <host>         If you wish to connect to a remote LM Studio instance,
                        specify the host here. Note that, in this case, lms will
                        connect using client identifier "lms-cli-remote-<random
                        chars>", which will not be a privileged client, and will
                        restrict usage of functionalities such as "lms push".
  --port <port>         The port where LM Studio can be reached. If not provided and
                        the host is set to "127.0.0.1" (default), the last used port
                        will be used; otherwise, 1234 will be used.

Logging Options:
  --log-level <level>   The level of logging to use (choices: "debug", "info",
                        "warn", "error", "none")
  --quiet               Suppress all logging
  --verbose             Enable verbose logging
```