### PR TITLE
Add --bind option to lms server start

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -15,11 +15,7 @@ export const DEFAULT_SERVER_PORT: number = 1234;
 /**
  * Checks if the HTTP server is running.
  */
-export async function checkHttpServer(
-  logger: SimpleLogger,
-  port: number,
-  host: string | undefined = undefined,
-) {
+export async function checkHttpServer(logger: SimpleLogger, port: number, host?: string) {
   const resolvedHost = host ?? "127.0.0.1";
   const url = `http://${resolvedHost}:${port}/lmstudio-greeting`;
   logger.debug(`Checking server at ${url}`);

--- a/src/subcommands/server.ts
+++ b/src/subcommands/server.ts
@@ -56,7 +56,7 @@ const start = addLogLevelOptions(
         text`
           Port to run the server on. If not provided, the server will run on the same port as the last
           time it was started.
-      `,
+        `,
       ).argParser(createRefinedNumberParser({ integer: true, min: 0, max: 65535 })),
     )
     .option(
@@ -65,14 +65,14 @@ const start = addLogLevelOptions(
         Network address to bind the server to. Use "0.0.0.0" to accept connections from the
         local network, or "127.0.0.1" (default) for localhost only. Can also be set via the
         LMS_SERVER_HOST environment variable.
-    `,
+      `,
     )
     .option(
       "--cors",
       text`
         Enable CORS on the server. Allows any website you visit to access the server. This is
         required if you are developing a web application.
-    `,
+      `,
     ),
 ).action(async options => {
   const { port, bind, cors = false, ...logArgs } = options;
@@ -85,15 +85,18 @@ const start = addLogLevelOptions(
   }
 
   // Priority order: CLI flag > Environment variable > Persisted setting > Default value
-  const envNetworkInterface = process.env.LMS_SERVER_HOST;
-  const resolvedNetworkInterface = bind ?? (envNetworkInterface || "127.0.0.1");
+  let envNetworkInterface = process.env.LMS_SERVER_HOST;
+  if (envNetworkInterface === "") {
+    envNetworkInterface = undefined;
+  }
+  const resolvedNetworkInterface = bind ?? envNetworkInterface ?? "127.0.0.1";
 
   const resolvedPort = port ?? (await getServerConfig(logger))?.port ?? DEFAULT_SERVER_PORT;
   logger.debug(`Attempting to start the server on port ${resolvedPort}...`);
 
   if (resolvedNetworkInterface !== "127.0.0.1") {
     logger.warnText`
-      Server will accept connections from the local network. Only use this if you know what you are doing!
+      Server will accept connections from the network. Only use this if you know what you are doing!
     `;
   }
 


### PR DESCRIPTION
Add a `--bind` option to `lms server start`, which lets the user specify the address that the server binds to. The user can also use `LMS_SERVER_HOST` env variable to control this value.

The code which checks the status of the server was tweaked to connect to the specified address, instead of always trying 127.0.0.1