### PR TITLE
Fix log stream exits early

### DIFF
--- a/src/subcommands/log.ts
+++ b/src/subcommands/log.ts
@@ -35,6 +35,8 @@ addLogLevelOptions(stream);
 
 stream.action(async options => {
   const logger = createLogger(options);
+  // We don't want to dispose the client immediately, instead of using 'using'
+  // we'll dispose it when the process exits.
   const client = await createClient(logger, options);
   const { json = false, stats = false, source = "model", filter } = options;
 


### PR DESCRIPTION
## Overview

Fixes the bug where running `lms log stream` would exit prematurely because the client would dispose instantly. Now we dispose based on the signals so the client is alive during the duration of the session.


https://github.com/user-attachments/assets/d90b5b58-3e21-48b4-bbfe-6bf6796d6195

