### PR TITLE
Re-enable help command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,10 @@ function createHelpConfiguration(maxWidth: number, helpMessageGap: number): Help
       return `${" ".repeat(HELP_MESSAGE_PADDING_LEFT)}${paddedName}`;
     },
     argumentDescription: (argument: { description?: string }) => argument.description ?? "",
-    visibleCommands: command => command.commands.filter(cmd => cmd.name() !== "help"),
+    visibleCommands(cmd) {
+      // @ts-expect-error - Commander.js types don't include the _hidden property, but it exists at runtime
+      return cmd.commands.filter(command => command._hidden !== true);
+    },
   };
 }
 


### PR DESCRIPTION
## Overview

This PR re-enables `lms help` and hides it from the help message

<img width="748" height="719" alt="image" src="https://github.com/user-attachments/assets/04debcff-2a5f-4b99-a305-65ed80ee2d7e" />