### PR TITLE
Workaround for ink backspace bug

### DIFF
--- a/src/subcommands/chat/react/ChatInput.tsx
+++ b/src/subcommands/chat/react/ChatInput.tsx
@@ -118,6 +118,7 @@ export const ChatInput = ({
 
     // Currently there is a bug in ink where backspace is detected as delete
     // so we handle both the same way for now.
+    // https://github.com/vadimdemedes/ink/issues/634
     if (key.delete === true) {
       setUserInputState(previousState => deleteBeforeCursor(previousState));
       return;


### PR DESCRIPTION
## Overview

While doing a sanity check on linux, found that ink is bugged in way that it interprets backspace as delete and hence this is a workaround to fix that

Ref: https://github.com/vadimdemedes/ink/issues/634
