### PR TITLE
Fix wrong model loaded after clarifying correct model

### DIFF
--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -202,7 +202,7 @@ loadCommand.action(async (pathArg, options: LoadCommandOptions) => {
     if (estimateOnly === true) {
       const estimate = await (
         model.type === "llm" ? client.llm : client.embedding
-      ).estimateResourcesUsage(model.path, loadConfig);
+      ).estimateResourcesUsage(model.modelKey, loadConfig);
       printEstimatedResourceUsage(model, loadConfig.contextLength, gpu, estimate, logger);
       return;
     }
@@ -277,7 +277,7 @@ loadCommand.action(async (pathArg, options: LoadCommandOptions) => {
   if (estimateOnly === true) {
     const estimate = await (
       model.type === "llm" ? client.llm : client.embedding
-    ).estimateResourcesUsage(model.path, loadConfig);
+    ).estimateResourcesUsage(model.modelKey, loadConfig);
     printEstimatedResourceUsage(model, loadConfig.contextLength, gpu, estimate, logger);
     return;
   }
@@ -361,7 +361,7 @@ async function loadModel(
   };
 
   process.addListener("SIGINT", sigintListener);
-  const llmModel = await (model.type === "llm" ? client.llm : client.embedding).load(path, {
+  const llmModel = await (model.type === "llm" ? client.llm : client.embedding).load(model.modelKey, {
     verbose: false,
     ttl: ttlSeconds,
     signal: abortController.signal,


### PR DESCRIPTION
I encountered a bug with `lms load`.

My `lms ls`:
```
You have 9 models, taking up 22.23 GB of disk space.

LLM                               PARAMS    ARCH       SIZE         
lfm2-350m@bf16                    350M      lfm2       713.84 MB    
lfm2-350m@f16                     350M      lfm2       711.48 MB    
```

After running `lms load lfm2-350m`, I clarified that I wanted to load the `@bf16` model in the interactive selection. However, the backend told me that the load was ambiguous, and loaded the `@f16` variant.

This PR fixes this bug. Note that no backend changes are needed, because the backend handles full identifiers correctly. The current `model.path` strips away variant information.

I tested this to ensure that the bug is fixed after this PR.