### PR TITLE
Add ctrl+w input support to `lms chat`

### DIFF
--- a/src/subcommands/chat/react/ChatInput.tsx
+++ b/src/subcommands/chat/react/ChatInput.tsx
@@ -5,6 +5,7 @@ import { InputPlaceholder } from "./InputPlaceholder.js";
 import {
   deleteAfterCursor,
   deleteBeforeCursor,
+  deleteWordBeforeCursor,
   insertTextAtCursor,
   moveCursorLeft,
   moveCursorRight,
@@ -124,6 +125,12 @@ export const ChatInput = ({
 
     if (key.backspace === true) {
       setUserInputState(previousState => deleteBeforeCursor(previousState));
+      return;
+    }
+
+    // Ctrl+W to delete word before cursor
+    if (key.ctrl === true && inputCharacter === "w") {
+      setUserInputState(previousState => deleteWordBeforeCursor(previousState));
       return;
     }
 


### PR DESCRIPTION
Add support for `ctrl+w` to delete the word before the cursor. This binding is widely supported in terminals and cli tools.

I tested this implementation, and seems to be working correctly. Also, see the unit tests which further describe the behavior of ctrl+w depending on the cursor position and text.

`ctrl+w` is not allowed to delete pasted segments.