### PR TITLE
Show runtime that the survey is conducted with

### DIFF
--- a/src/subcommands/runtime/survey.ts
+++ b/src/subcommands/runtime/survey.ts
@@ -140,13 +140,13 @@ surveyCommand.action(async function (commandOptions) {
   // Find and render the llama.cpp engine's survey
   const engineSurvey = surveyResult.engines.find(engine => engine.engine === "llama.cpp");
   if (engineSurvey !== undefined) {
-    if (commandOptions.verbose === true) {
-      console.info(chalk.dim(`Survey by ${engineSurvey.name} (${engineSurvey.version})`));
-    }
+    console.info(chalk.dim(`Survey by ${engineSurvey.name} (${engineSurvey.version})`));
     renderEngineSurvey(engineSurvey);
   } else {
     // If llama.cpp survey is not available, render the first engine's survey as a fallback
-    renderEngineSurvey(surveyResult.engines[0]);
+    const firstEngine = surveyResult.engines[0];
+    console.info(chalk.dim(`Survey by ${firstEngine.name} (${firstEngine.version})`));
+    renderEngineSurvey(firstEngine);
   }
 });
 


### PR DESCRIPTION
I called `lms runtime survey` and was momentarily confused why it was detecting zero GPUs. Turns out, the survey was done with the CPU runtime. This info is not printed though, unless the `--verbose` flag is enabled. Hopefully this information can be promoted to regular output instead of verbose output, since it's unclear why `lms` is refusing to show GPUs.

Result after this PR, on my macbook:
<img width="441" height="102" alt="Screenshot 2026-01-09 at 3 24 42 PM" src="https://github.com/user-attachments/assets/1ab1f32d-3b3c-4514-a875-7a2b4755bef1" />
