### PR TITLE
`lms log stream` - Default to displaying input and output

### DIFF
--- a/src/subcommands/log.ts
+++ b/src/subcommands/log.ts
@@ -56,7 +56,6 @@ stream.action(async options => {
   let filterTypes: string[] = [];
   if (source === "model") {
     if (filter === undefined) {
-      // Default behavior with warning
       filterTypes = ["input", "output"];
     } else {
       // Check for empty string


### PR DESCRIPTION
## Overview

Now, `lms` will display both input and output messages using `log stream`

<img width="1839" height="374" alt="image" src="https://github.com/user-attachments/assets/ddfc1893-8052-4edd-a8bb-e3089b8ffcfd" />
