### PR TITLE
Fix lms server status --json to output JSON only

### DIFF
--- a/src/subcommands/server.ts
+++ b/src/subcommands/server.ts
@@ -194,13 +194,15 @@ status.action(async options => {
   if (port !== undefined) {
     running = await checkHttpServer(logger, port, networkInterface);
   }
+  if (json) {
+    process.stdout.write(JSON.stringify({ running, port }) + "\n");
+    return;
+  }
+
   if (running) {
     logger.info(`The server is running on port ${port}.`);
   } else {
     logger.info(`The server is not running.`);
-  }
-  if (json) {
-    process.stdout.write(JSON.stringify({ running, port }) + "\n");
   }
 });
 


### PR DESCRIPTION
## Summary
- return immediately after writing JSON in server status command
- keep human-readable status logs for non-JSON mode

## Result
`lms server status --json` now prints only JSON, with no extra text before it.

Fixes #173