### PR TITLE
Show usage stats when running lms chat --verbose

### DIFF
--- a/src/subcommands/chat/index.tsx
+++ b/src/subcommands/chat/index.tsx
@@ -230,7 +230,7 @@ chatCommand.action(async (model, options: ChatCommandOptions) => {
       client,
       chat,
       {
-        stats: options.stats,
+        stats: options.stats || options.verbose === true,
         ttl,
       },
       llm,
@@ -246,7 +246,7 @@ chatCommand.action(async (model, options: ChatCommandOptions) => {
       process.exit(1);
     }
     await handleNonInteractiveChat(llm, chat, providedPrompt, logger, {
-      stats: options.stats,
+      stats: options.stats || options.verbose === true,
       ttl,
     });
   } else {


### PR DESCRIPTION
## Summary
- treat `--verbose` as enabling chat usage stats
- apply this behavior to both interactive and non-interactive chat flows

## Result
Running `lms chat --verbose` now shows usage stats without requiring an extra `--stats` flag.

Fixes #238