### PR TITLE
Require libatomic.so.1 for linux systems when running `lms daemon update`

### DIFF
--- a/src/subcommands/daemon/update.ts
+++ b/src/subcommands/daemon/update.ts
@@ -62,9 +62,9 @@ const updateDaemon = new Command<[], DaemonUpdateCommandOptions>()
     if (process.platform === "linux") {
       const libatomicCheck = checkLinuxLibatomic();
       if (libatomicCheck.status === "ldconfig-unavailable") {
-        logger.error(`"ldconfig" must be available on your PATH before updating.
+        logger.info(`Could not update: "ldconfig" must be available on your PATH before updating.
 
-Please ensure ldconfig is installed and on your PATH, then run this again:
+Please ensure ldconfig is installed and in your PATH, then run this again:
 
       lms daemon update
 


### PR DESCRIPTION
Node 25 requires `libatomic.so.1`, so start requiring this now in preparation for our update to node 25.

This code can be removed after `llmster` is migrated to node 25, as this warning only needs to be shown for node 22 systems.

I tested this on a linux machine:
```
$ ./lms daemon update
Error: Cannot stage daemon update because libatomic.so.1 is missing. This library is now a pre-requisite to use the daemon.
Install it, then retry `lms daemon update`:
  Debian/Ubuntu: sudo apt-get update && sudo apt-get install -y libatomic1
  Fedora/RHEL:  sudo dnf install -y libatomic

If this libatomic check is not working as expected on your system, update lms with:
  curl -fsSL https://lmstudio.ai/install.sh | bash
$ sudo apt install -y libatomic1 &> /dev/null 
$ ./lms daemon update
Starting llmster upgrade using /home/lm-studio/neil/llmster/electron/dist/llmster/llmster...
Checking for updates (channel: stable, current: 0.0.7+1)
Update check failed: Connection refused when checking for llmster updates. Are network requests blocked or are you offline?
```