### PR TITLE
Add @types/react to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@types/columnify": "^1.5.4",
     "@types/node": "^20.12.5",
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.2.0",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.56.0",


### PR DESCRIPTION
Fix bug during build that caused `TS7016` for `react` and `react/jsx-runtime`.

According to AI explanations, since `@types/react` is an optional peer dependency it may not always be installed, which causes CI builds to fail. This is the recommended fix to ensure that the types are always installed.
