### PR TITLE
Remove unref while checking http server

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -21,8 +21,16 @@ export async function checkHttpServer(logger: SimpleLogger, port: number, host?:
   logger.debug(`Checking server at ${url}`);
   try {
     const abortController = new AbortController();
-    setTimeout(() => abortController.abort(new Error("Connection timed out.")), 500).unref();
-    const response = await fetch(url, { signal: abortController.signal });
+    const timeout = setTimeout(
+      () => abortController.abort(new Error("Connection timed out.")),
+      500,
+    );
+    let response;
+    try {
+      response = await fetch(url, { signal: abortController.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
     if (response.status !== 200) {
       logger.debug(`Status is not 200: ${response.status}`);
       return false;


### PR DESCRIPTION
## Overview

Fixes the bug where `lms server` commands would not work for Linux ARM machines. This is due to `setTimeout.unref()` not being a function on the deno version we are using.

<img width="1252" height="1376" alt="image" src="https://github.com/user-attachments/assets/bba0e292-cafb-4d01-9e0d-aa32c642b68b" />


