### PR TITLE
.

### DIFF
--- a/src/subcommands/daemon/update.ts
+++ b/src/subcommands/daemon/update.ts
@@ -17,9 +17,12 @@ type LibatomicCheckResult =
 
 function checkLinuxLibatomic(): LibatomicCheckResult {
   try {
-    const result = spawnSync("ldconfig", ["-p"], { encoding: "utf-8" });
+    let result = spawnSync("ldconfig", ["-p"], { encoding: "utf-8" });
     if (result.error !== undefined) {
-      return { status: "ldconfig-unavailable", error: result.error.message };
+      result = spawnSync("/usr/sbin/ldconfig", ["-p"], { encoding: "utf-8" });
+      if (result.error !== undefined) {
+        return { status: "ldconfig-unavailable", error: result.error.message };
+      }
     }
     if (result.status !== 0) {
       const statusDescription =


### PR DESCRIPTION
### Summary

- Add fallback to` /usr/sbin/ldconfig` when `ldconfig` is not found in `$PATH`

### Description

Some Linux distributions (notably Alpine Linux, Suse) do not include `/usr/sbin` in the default `PATH`. This causes `lms daemon update` to fail on those systems, even though `ldconfig` is installed and available at `/usr/sbin/ldconfig`.

This change adds a fallback: if `ldconfig` is not found via `$PATH`, the `checkLinuxLibatomic()` function now also tries `/usr/sbin/ldconfig` before reporting that `ldconfig` is unavailable.

Fixes #532.