### PR TITLE
Show load progress in CLI spinners

### DIFF
--- a/src/subcommands/chat/util.ts
+++ b/src/subcommands/chat/util.ts
@@ -12,6 +12,15 @@ export async function loadModelWithProgress(
 ): Promise<LLM> {
   const spinner = new Spinner(`Loading ${modelName}`);
   const abortController = new AbortController();
+  let lastProgressUpdateTime = 0;
+  const updateSpinnerProgress = (progress: number) => {
+    const now = Date.now();
+    if (progress < 1 && now - lastProgressUpdateTime < 100) {
+      return;
+    }
+    spinner.setText(`Loading ${modelName} ${(progress * 100).toFixed(0)}%`);
+    lastProgressUpdateTime = now;
+  };
 
   const sigintListener = () => {
     spinner.stop();
@@ -26,6 +35,7 @@ export async function loadModelWithProgress(
       verbose: false,
       signal: abortController.signal,
       ttl,
+      onProgress: updateSpinnerProgress,
     });
     return llmModel;
   } finally {

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -512,6 +512,15 @@ async function loadModel({
   const spinner = new Spinner(spinnerText);
   const startTime = Date.now();
   const abortController = new AbortController();
+  let lastProgressUpdateTime = 0;
+  const updateSpinnerProgress = (progress: number) => {
+    const now = Date.now();
+    if (progress < 1 && now - lastProgressUpdateTime < 100) {
+      return;
+    }
+    spinner.setText(`${spinnerText} ${(progress * 100).toFixed(0)}%`);
+    lastProgressUpdateTime = now;
+  };
 
   const sigintListener = () => {
     spinner.stop();
@@ -530,6 +539,7 @@ async function loadModel({
       config,
       identifier,
       deviceIdentifier,
+      onProgress: updateSpinnerProgress,
     });
   } finally {
     process.removeListener("SIGINT", sigintListener);


### PR DESCRIPTION
Show model load progress consistently with GUI and `lms chat`'s `/model`.

<img width="372" height="50" alt="Screenshot 2026-05-28 at 10 22 27 AM" src="https://github.com/user-attachments/assets/bf00e0ca-7b28-42c2-b984-458fdfca028b" />
