### PR TITLE
LSEP: speculative decoding load flags

### DIFF
--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -5,44 +5,44 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     expect(resolveCliSpeculativeDecodingLoadConfig({})).toEqual({});
   });
 
-  it("creates a canonical draftModel strategy", () => {
+  it("creates flat draft-model load config", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftModel: "test/draft",
       }),
     ).toEqual({
-      speculativeDecoding: [
-        {
-          type: "draftModel",
-          draftModel: "test/draft",
-        },
-      ],
+      speculativeDraftMtp: false,
+      speculativeDraftModel: "test/draft",
     });
   });
 
-  it("includes optional max and min draft token settings", () => {
+  it("includes optional shared draft tuning settings", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftModel: "test/draft",
         speculativeDraftMaxTokens: 7,
         speculativeDraftMinTokens: 2,
+        speculativeDraftMinContinueProbability: 0.25,
       }),
     ).toEqual({
-      speculativeDecoding: [
-        {
-          type: "draftModel",
-          draftModel: "test/draft",
-          maxTokensToDraft: 7,
-          minDraftLengthToConsider: 2,
-        },
-      ],
+      speculativeDraftMtp: false,
+      speculativeDraftModel: "test/draft",
+      speculativeDraftMaxTokens: 7,
+      speculativeDraftMinTokens: 2,
+      speculativeDraftMinContinueProbability: 0.25,
     });
   });
 
-  it("rejects draft token flags without a draft model", () => {
+  it("rejects draft tuning flags without a draft model", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMaxTokens: 7,
+      }),
+    ).toThrow("--speculative-draft-model");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftMinContinueProbability: 0.25,
       }),
     ).toThrow("--speculative-draft-model");
   });

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -8,10 +8,12 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
   it("creates flat draft-model load config", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftSimple: true,
         speculativeDraftModel: "test/draft",
       }),
     ).toEqual({
       speculativeDraftMtp: false,
+      speculativeDraftSimple: true,
       speculativeDraftModel: "test/draft",
     });
   });
@@ -19,6 +21,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
   it("includes optional shared draft tuning settings", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftSimple: true,
         speculativeDraftModel: "test/draft",
         speculativeDraftMaxTokens: 7,
         speculativeDraftMinTokens: 2,
@@ -26,6 +29,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       }),
     ).toEqual({
       speculativeDraftMtp: false,
+      speculativeDraftSimple: true,
       speculativeDraftModel: "test/draft",
       speculativeDraftMaxTokens: 7,
       speculativeDraftMinTokens: 2,
@@ -33,23 +37,81 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     });
   });
 
-  it("rejects draft tuning flags without a draft model", () => {
+  it("creates Draft MTP load config", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftMtp: true,
+        speculativeDraftMaxTokens: 7,
+      }),
+    ).toEqual({
+      speculativeDraftMtp: true,
+      speculativeDraftMaxTokens: 7,
+    });
+  });
+
+  it("creates explicit Draft MTP off config", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftMtp: false,
+      }),
+    ).toEqual({
+      speculativeDraftMtp: false,
+    });
+  });
+
+  it("rejects draft tuning flags without a draft type", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMaxTokens: 7,
       }),
-    ).toThrow("--speculative-draft-model");
+    ).toThrow("--speculative-draft-simple or --speculative-draft-mtp");
 
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMinContinueProbability: 0.25,
       }),
-    ).toThrow("--speculative-draft-model");
+    ).toThrow("--speculative-draft-simple or --speculative-draft-mtp");
+  });
+
+  it("rejects draft model without Draft Simple", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--speculative-draft-model requires --speculative-draft-simple");
+  });
+
+  it("rejects Draft Simple without a draft model", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftSimple: true,
+      }),
+    ).toThrow("--speculative-draft-simple requires --speculative-draft-model");
+  });
+
+  it("rejects Draft MTP with Draft Simple", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftMtp: true,
+        speculativeDraftSimple: true,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--speculative-draft-mtp and --speculative-draft-simple");
+  });
+
+  it("rejects Draft MTP with a draft model resource", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftMtp: true,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--speculative-draft-mtp cannot be combined with --speculative-draft-model");
   });
 
   it("rejects min draft tokens greater than max draft tokens", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftSimple: true,
         speculativeDraftModel: "test/draft",
         speculativeDraftMaxTokens: 2,
         speculativeDraftMinTokens: 7,

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -1,0 +1,59 @@
+import { resolveCliSpeculativeDecodingLoadConfig } from "./loadSpeculativeDecoding.js";
+
+describe("resolveCliSpeculativeDecodingLoadConfig", () => {
+  it("omits speculative decoding when no speculative flags are provided", () => {
+    expect(resolveCliSpeculativeDecodingLoadConfig({})).toEqual({});
+  });
+
+  it("creates a canonical draftModel strategy", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toEqual({
+      speculativeDecoding: [
+        {
+          type: "draftModel",
+          draftModel: "test/draft",
+        },
+      ],
+    });
+  });
+
+  it("includes optional max and min draft token settings", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftModel: "test/draft",
+        speculativeDraftMaxTokens: 7,
+        speculativeDraftMinTokens: 2,
+      }),
+    ).toEqual({
+      speculativeDecoding: [
+        {
+          type: "draftModel",
+          draftModel: "test/draft",
+          maxTokensToDraft: 7,
+          minDraftLengthToConsider: 2,
+        },
+      ],
+    });
+  });
+
+  it("rejects draft token flags without a draft model", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftMaxTokens: 7,
+      }),
+    ).toThrow("--speculative-draft-model");
+  });
+
+  it("rejects min draft tokens greater than max draft tokens", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftModel: "test/draft",
+        speculativeDraftMaxTokens: 2,
+        speculativeDraftMinTokens: 7,
+      }),
+    ).toThrow("--speculative-draft-min-tokens");
+  });
+});

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -25,6 +25,7 @@ import { runPromptWithExitHandling } from "../prompt.js";
 import { Spinner } from "../Spinner.js";
 import { createRefinedNumberParser } from "../types/refinedNumber.js";
 import { fuzzyHighlightOptions, searchTheme } from "../inquirerTheme.js";
+import { resolveCliSpeculativeDecodingLoadConfig } from "./loadSpeculativeDecoding.js";
 
 const gpuOptionParser = (str: string): number => {
   str = str.trim().toLowerCase();
@@ -50,12 +51,44 @@ type LoadCommandOptions = OptionValues &
     gpu?: number;
     contextLength?: number;
     parallel?: number;
+    speculativeDraftModel?: string;
+    speculativeDraftMaxTokens?: number;
+    speculativeDraftMinTokens?: number;
     exact?: boolean;
     local?: boolean;
     identifier?: string;
     yes?: boolean;
     estimateOnly?: boolean;
   };
+
+function assertSpeculativeDecodingSupportedForCliModel({
+  model,
+  loadConfig,
+  logger,
+}: {
+  model: ModelInfo;
+  loadConfig: LLMLoadModelConfig;
+  logger: SimpleLogger;
+}): void {
+  const speculativeDecoding = loadConfig.speculativeDecoding;
+  if (
+    speculativeDecoding === undefined ||
+    speculativeDecoding.length === 0 ||
+    model.type !== "embedding"
+  ) {
+    return;
+  }
+
+  logger.errorWithoutPrefix(
+    makeTitledPrettyError(
+      "Unsupported load option",
+      text`
+        Speculative decoding can only be configured for LLM models.
+      `,
+    ).message,
+  );
+  process.exit(1);
+}
 
 function hasDuplicatesOnSameDevice(models: Array<ModelInfo>): boolean {
   const deviceIdentifierCounts = new Map<string | null, number>();
@@ -123,6 +156,32 @@ const loadCommand = new Command<[], LoadCommandOptions>()
   )
   .addOption(
     new Option(
+      "--speculative-draft-model <model>",
+      text`
+        Load-time draft model to use for draft-model speculative decoding.
+      `,
+    ),
+  )
+  .addOption(
+    new Option(
+      "--speculative-draft-max-tokens <count>",
+      text`
+        Maximum number of draft tokens to generate per speculative decoding step. Requires
+        --speculative-draft-model.
+      `,
+    ).argParser(createRefinedNumberParser({ integer: true, min: 1 })),
+  )
+  .addOption(
+    new Option(
+      "--speculative-draft-min-tokens <count>",
+      text`
+        Minimum draft length to consider for speculative decoding. Requires
+        --speculative-draft-model.
+      `,
+    ).argParser(createRefinedNumberParser({ integer: true, min: 0 })),
+  )
+  .addOption(
+    new Option(
       "--exact",
       text`
         Only load the model if the path provided matches the model exactly. Fails if the path
@@ -169,6 +228,9 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     gpu,
     contextLength,
     parallel: maxParallelPredictions,
+    speculativeDraftModel,
+    speculativeDraftMaxTokens,
+    speculativeDraftMinTokens,
     yes = false,
     exact = false,
     local = false,
@@ -178,6 +240,11 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   const loadConfig: LLMLoadModelConfig = {
     contextLength,
     maxParallelPredictions,
+    ...resolveCliSpeculativeDecodingLoadConfig({
+      speculativeDraftModel,
+      speculativeDraftMaxTokens,
+      speculativeDraftMinTokens,
+    }),
   };
   if (gpu !== undefined) {
     loadConfig.gpu = {
@@ -267,6 +334,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
       process.exit(1);
     }
     if (estimateOnly === true) {
+      assertSpeculativeDecodingSupportedForCliModel({ model, loadConfig, logger });
       const estimate = await (
         model.type === "llm" ? client.llm : client.embedding
       ).estimateResourcesUsage(model.modelKey, loadConfig, {
@@ -277,6 +345,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     }
 
     const loadNamespace = model.type === "embedding" ? client.embedding : client.llm;
+    assertSpeculativeDecodingSupportedForCliModel({ model, loadConfig, logger });
     await loadModel({
       logger,
       namespace: loadNamespace,
@@ -393,6 +462,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   }
 
   if (estimateOnly === true) {
+    assertSpeculativeDecodingSupportedForCliModel({ model, loadConfig, logger });
     const estimate = await (
       model.type === "llm" ? client.llm : client.embedding
     ).estimateResourcesUsage(model.modelKey, loadConfig, {
@@ -415,6 +485,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   });
 
   const loadNamespace = model.type === "embedding" ? client.embedding : client.llm;
+  assertSpeculativeDecodingSupportedForCliModel({ model, loadConfig, logger });
   await loadModel({
     logger,
     namespace: loadNamespace,

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -54,6 +54,7 @@ type LoadCommandOptions = OptionValues &
     speculativeDraftModel?: string;
     speculativeDraftMaxTokens?: number;
     speculativeDraftMinTokens?: number;
+    speculativeDraftMinContinueProbability?: number;
     exact?: boolean;
     local?: boolean;
     identifier?: string;
@@ -70,12 +71,13 @@ function assertSpeculativeDecodingSupportedForCliModel({
   loadConfig: LLMLoadModelConfig;
   logger: SimpleLogger;
 }): void {
-  const speculativeDecoding = loadConfig.speculativeDecoding;
-  if (
-    speculativeDecoding === undefined ||
-    speculativeDecoding.length === 0 ||
-    model.type !== "embedding"
-  ) {
+  const hasSpeculativeDecodingLoadConfig =
+    loadConfig.speculativeDraftMtp !== undefined ||
+    loadConfig.speculativeDraftModel !== undefined ||
+    loadConfig.speculativeDraftMaxTokens !== undefined ||
+    loadConfig.speculativeDraftMinTokens !== undefined ||
+    loadConfig.speculativeDraftMinContinueProbability !== undefined;
+  if (!hasSpeculativeDecodingLoadConfig || model.type !== "embedding") {
     return;
   }
 
@@ -182,6 +184,15 @@ const loadCommand = new Command<[], LoadCommandOptions>()
   )
   .addOption(
     new Option(
+      "--speculative-draft-min-continue-probability <probability>",
+      text`
+        Continue drafting while token probability is at or above this threshold. Requires
+        --speculative-draft-model.
+      `,
+    ).argParser(createRefinedNumberParser({ min: 0, max: 1 })),
+  )
+  .addOption(
+    new Option(
       "--exact",
       text`
         Only load the model if the path provided matches the model exactly. Fails if the path
@@ -231,6 +242,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     speculativeDraftModel,
     speculativeDraftMaxTokens,
     speculativeDraftMinTokens,
+    speculativeDraftMinContinueProbability,
     yes = false,
     exact = false,
     local = false,
@@ -244,6 +256,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
       speculativeDraftModel,
       speculativeDraftMaxTokens,
       speculativeDraftMinTokens,
+      speculativeDraftMinContinueProbability,
     }),
   };
   if (gpu !== undefined) {

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -51,6 +51,8 @@ type LoadCommandOptions = OptionValues &
     gpu?: number;
     contextLength?: number;
     parallel?: number;
+    speculativeDraftMtp?: boolean;
+    speculativeDraftSimple?: boolean;
     speculativeDraftModel?: string;
     speculativeDraftMaxTokens?: number;
     speculativeDraftMinTokens?: number;
@@ -73,6 +75,7 @@ function assertSpeculativeDecodingSupportedForCliModel({
 }): void {
   const hasSpeculativeDecodingLoadConfig =
     loadConfig.speculativeDraftMtp !== undefined ||
+    loadConfig.speculativeDraftSimple !== undefined ||
     loadConfig.speculativeDraftModel !== undefined ||
     loadConfig.speculativeDraftMaxTokens !== undefined ||
     loadConfig.speculativeDraftMinTokens !== undefined ||
@@ -158,9 +161,33 @@ const loadCommand = new Command<[], LoadCommandOptions>()
   )
   .addOption(
     new Option(
+      "--speculative-draft-mtp",
+      text`
+        Enable load-time Draft MTP speculative decoding when supported by the model.
+      `,
+    ).default(undefined),
+  )
+  .addOption(
+    new Option(
+      "--no-speculative-draft-mtp",
+      text`
+        Disable load-time Draft MTP speculative decoding.
+      `,
+    ).default(undefined),
+  )
+  .addOption(
+    new Option(
+      "--speculative-draft-simple",
+      text`
+        Enable load-time Draft Simple speculative decoding using --speculative-draft-model.
+      `,
+    ),
+  )
+  .addOption(
+    new Option(
       "--speculative-draft-model <model>",
       text`
-        Load-time draft model to use for draft-model speculative decoding.
+        Draft model resource to use with --speculative-draft-simple.
       `,
     ),
   )
@@ -169,7 +196,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-max-tokens <count>",
       text`
         Maximum number of draft tokens to generate per speculative decoding step. Requires
-        --speculative-draft-model.
+        --speculative-draft-simple or --speculative-draft-mtp.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 1 })),
   )
@@ -178,7 +205,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-min-tokens <count>",
       text`
         Minimum draft length to consider for speculative decoding. Requires
-        --speculative-draft-model.
+        --speculative-draft-simple or --speculative-draft-mtp.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 0 })),
   )
@@ -187,7 +214,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-min-continue-probability <probability>",
       text`
         Continue drafting while token probability is at or above this threshold. Requires
-        --speculative-draft-model.
+        --speculative-draft-simple or --speculative-draft-mtp.
       `,
     ).argParser(createRefinedNumberParser({ min: 0, max: 1 })),
   )
@@ -239,6 +266,8 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     gpu,
     contextLength,
     parallel: maxParallelPredictions,
+    speculativeDraftMtp,
+    speculativeDraftSimple,
     speculativeDraftModel,
     speculativeDraftMaxTokens,
     speculativeDraftMinTokens,
@@ -253,6 +282,8 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     contextLength,
     maxParallelPredictions,
     ...resolveCliSpeculativeDecodingLoadConfig({
+      speculativeDraftMtp,
+      speculativeDraftSimple,
       speculativeDraftModel,
       speculativeDraftMaxTokens,
       speculativeDraftMinTokens,

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -4,17 +4,30 @@ export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
   speculativeDraftModel?: string;
   speculativeDraftMaxTokens?: number;
   speculativeDraftMinTokens?: number;
+  speculativeDraftMinContinueProbability?: number;
 }
 
 export function resolveCliSpeculativeDecodingLoadConfig({
   speculativeDraftModel,
   speculativeDraftMaxTokens,
   speculativeDraftMinTokens,
-}: ResolveCliSpeculativeDecodingLoadConfigOpts): Pick<LLMLoadModelConfig, "speculativeDecoding"> {
+  speculativeDraftMinContinueProbability,
+}: ResolveCliSpeculativeDecodingLoadConfigOpts): Pick<
+  LLMLoadModelConfig,
+  | "speculativeDraftMtp"
+  | "speculativeDraftModel"
+  | "speculativeDraftMaxTokens"
+  | "speculativeDraftMinTokens"
+  | "speculativeDraftMinContinueProbability"
+> {
   if (speculativeDraftModel === undefined) {
-    if (speculativeDraftMaxTokens !== undefined || speculativeDraftMinTokens !== undefined) {
+    if (
+      speculativeDraftMaxTokens !== undefined ||
+      speculativeDraftMinTokens !== undefined ||
+      speculativeDraftMinContinueProbability !== undefined
+    ) {
       throw new Error(
-        "--speculative-draft-max-tokens and --speculative-draft-min-tokens require --speculative-draft-model.",
+        "--speculative draft tuning flags require --speculative-draft-model.",
       );
     }
 
@@ -36,17 +49,16 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   }
 
   return {
-    speculativeDecoding: [
-      {
-        type: "draftModel",
-        draftModel: speculativeDraftModel,
-        ...(speculativeDraftMaxTokens !== undefined
-          ? { maxTokensToDraft: speculativeDraftMaxTokens }
-          : {}),
-        ...(speculativeDraftMinTokens !== undefined
-          ? { minDraftLengthToConsider: speculativeDraftMinTokens }
-          : {}),
-      },
-    ],
+    speculativeDraftMtp: false,
+    speculativeDraftModel,
+    ...(speculativeDraftMaxTokens !== undefined
+      ? { speculativeDraftMaxTokens: speculativeDraftMaxTokens }
+      : {}),
+    ...(speculativeDraftMinTokens !== undefined
+      ? { speculativeDraftMinTokens: speculativeDraftMinTokens }
+      : {}),
+    ...(speculativeDraftMinContinueProbability !== undefined
+      ? { speculativeDraftMinContinueProbability: speculativeDraftMinContinueProbability }
+      : {}),
   };
 }

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -1,6 +1,8 @@
 import { type LLMLoadModelConfig } from "@lmstudio/sdk";
 
 export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
+  speculativeDraftMtp?: boolean;
+  speculativeDraftSimple?: boolean;
   speculativeDraftModel?: string;
   speculativeDraftMaxTokens?: number;
   speculativeDraftMinTokens?: number;
@@ -8,6 +10,8 @@ export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
 }
 
 export function resolveCliSpeculativeDecodingLoadConfig({
+  speculativeDraftMtp,
+  speculativeDraftSimple,
   speculativeDraftModel,
   speculativeDraftMaxTokens,
   speculativeDraftMinTokens,
@@ -15,27 +19,41 @@ export function resolveCliSpeculativeDecodingLoadConfig({
 }: ResolveCliSpeculativeDecodingLoadConfigOpts): Pick<
   LLMLoadModelConfig,
   | "speculativeDraftMtp"
+  | "speculativeDraftSimple"
   | "speculativeDraftModel"
   | "speculativeDraftMaxTokens"
   | "speculativeDraftMinTokens"
   | "speculativeDraftMinContinueProbability"
 > {
-  if (speculativeDraftModel === undefined) {
-    if (
-      speculativeDraftMaxTokens !== undefined ||
-      speculativeDraftMinTokens !== undefined ||
-      speculativeDraftMinContinueProbability !== undefined
-    ) {
-      throw new Error(
-        "--speculative draft tuning flags require --speculative-draft-model.",
-      );
-    }
+  const hasDraftTuning =
+    speculativeDraftMaxTokens !== undefined ||
+    speculativeDraftMinTokens !== undefined ||
+    speculativeDraftMinContinueProbability !== undefined;
 
-    return {};
+  if (speculativeDraftMtp === true && speculativeDraftSimple === true) {
+    throw new Error("--speculative-draft-mtp and --speculative-draft-simple cannot both be used.");
   }
 
-  if (speculativeDraftModel.length === 0) {
+  if (speculativeDraftModel !== undefined && speculativeDraftModel.length === 0) {
     throw new Error("--speculative-draft-model must not be empty.");
+  }
+
+  if (speculativeDraftMtp === true && speculativeDraftModel !== undefined) {
+    throw new Error("--speculative-draft-mtp cannot be combined with --speculative-draft-model.");
+  }
+
+  if (speculativeDraftSimple !== true && speculativeDraftModel !== undefined) {
+    throw new Error("--speculative-draft-model requires --speculative-draft-simple.");
+  }
+
+  if (speculativeDraftSimple === true && speculativeDraftModel === undefined) {
+    throw new Error("--speculative-draft-simple requires --speculative-draft-model.");
+  }
+
+  if (speculativeDraftMtp !== true && speculativeDraftSimple !== true && hasDraftTuning) {
+    throw new Error(
+      "--speculative draft tuning flags require --speculative-draft-simple or --speculative-draft-mtp.",
+    );
   }
 
   if (
@@ -48,9 +66,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     );
   }
 
-  return {
-    speculativeDraftMtp: false,
-    speculativeDraftModel,
+  const tuningConfig = {
     ...(speculativeDraftMaxTokens !== undefined
       ? { speculativeDraftMaxTokens: speculativeDraftMaxTokens }
       : {}),
@@ -60,5 +76,33 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     ...(speculativeDraftMinContinueProbability !== undefined
       ? { speculativeDraftMinContinueProbability: speculativeDraftMinContinueProbability }
       : {}),
+  };
+
+  if (speculativeDraftMtp === undefined && speculativeDraftSimple === undefined) {
+    return {};
+  }
+
+  if (speculativeDraftMtp === true) {
+    return {
+      speculativeDraftMtp: true,
+      ...tuningConfig,
+    };
+  }
+
+  if (speculativeDraftMtp === false && speculativeDraftSimple !== true) {
+    return {
+      speculativeDraftMtp: false,
+    };
+  }
+
+  if (speculativeDraftSimple !== true) {
+    return {};
+  }
+
+  return {
+    speculativeDraftMtp: false,
+    speculativeDraftSimple: true,
+    speculativeDraftModel: speculativeDraftModel,
+    ...tuningConfig,
   };
 }

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -1,0 +1,52 @@
+import { type LLMLoadModelConfig } from "@lmstudio/sdk";
+
+export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
+  speculativeDraftModel?: string;
+  speculativeDraftMaxTokens?: number;
+  speculativeDraftMinTokens?: number;
+}
+
+export function resolveCliSpeculativeDecodingLoadConfig({
+  speculativeDraftModel,
+  speculativeDraftMaxTokens,
+  speculativeDraftMinTokens,
+}: ResolveCliSpeculativeDecodingLoadConfigOpts): Pick<LLMLoadModelConfig, "speculativeDecoding"> {
+  if (speculativeDraftModel === undefined) {
+    if (speculativeDraftMaxTokens !== undefined || speculativeDraftMinTokens !== undefined) {
+      throw new Error(
+        "--speculative-draft-max-tokens and --speculative-draft-min-tokens require --speculative-draft-model.",
+      );
+    }
+
+    return {};
+  }
+
+  if (speculativeDraftModel.length === 0) {
+    throw new Error("--speculative-draft-model must not be empty.");
+  }
+
+  if (
+    speculativeDraftMaxTokens !== undefined &&
+    speculativeDraftMinTokens !== undefined &&
+    speculativeDraftMinTokens > speculativeDraftMaxTokens
+  ) {
+    throw new Error(
+      "--speculative-draft-min-tokens must be less than or equal to --speculative-draft-max-tokens.",
+    );
+  }
+
+  return {
+    speculativeDecoding: [
+      {
+        type: "draftModel",
+        draftModel: speculativeDraftModel,
+        ...(speculativeDraftMaxTokens !== undefined
+          ? { maxTokensToDraft: speculativeDraftMaxTokens }
+          : {}),
+        ...(speculativeDraftMinTokens !== undefined
+          ? { minDraftLengthToConsider: speculativeDraftMinTokens }
+          : {}),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

Adds `lms load` support for load-time speculative decoding fields:

- draft model
- draft max tokens
- draft min tokens
- draft min continue probability

When a draft model is supplied, the CLI explicitly disables Draft MTP so model defaults do not conflict.

## Validation

- `npm test -- --runTestsByPath src/subcommands/load.test.ts`
