### PR TITLE
Add reasoning controls to lms chat

### DIFF
--- a/src/subcommands/chat/index.tsx
+++ b/src/subcommands/chat/index.tsx
@@ -16,10 +16,12 @@ import { render } from "ink";
 import { ChatComponent } from "./react/Chat.js";
 import { getCachedModelCatalogOrFetch } from "./catalogHelpers.js";
 import { maybeGetLLM } from "./getLLM.js";
+import { REASONING_MODES, type ReasoningMode } from "./reasoning.js";
 
 interface StartPredictionOpts {
   stats?: true;
   ttl: number;
+  reasoningMode: ReasoningMode;
 }
 
 type ChatCommandOptions = OptionValues &
@@ -31,6 +33,7 @@ type ChatCommandOptions = OptionValues &
     ttl: number;
     dontFetchCatalog: boolean;
     yes?: boolean;
+    reasoning: ReasoningMode;
   };
 
 export const DEFAULT_SYSTEM_PROMPT =
@@ -122,7 +125,13 @@ export async function handleNonInteractiveChat(
   opts: StartPredictionOpts,
 ): Promise<void> {
   try {
-    const { result, lastFragment } = await executePrediction(llm, chat, prompt);
+    const { result, lastFragment } = await executePrediction(
+      llm,
+      chat,
+      prompt,
+      undefined,
+      opts.reasoningMode,
+    );
 
     if (opts.stats !== undefined) {
       displayVerboseStats(result.stats, logger.info.bind(logger));
@@ -159,6 +168,7 @@ export async function startInteractiveChat(
         chat={chat}
         stats={opts.stats}
         ttl={opts.ttl}
+        reasoningMode={opts.reasoningMode}
         onExit={() => {
           resolve();
         }}
@@ -182,6 +192,11 @@ const chatCommandBase = new Command<[], ChatCommandOptions>()
     new Option("--ttl <ttl>", "Time (in seconds) to keep the model loaded after the chat ends")
       .argParser(createRefinedNumberParser({ integer: true, min: 1 }))
       .default(3600),
+  )
+  .addOption(
+    new Option("--reasoning <mode>", "Reasoning mode for this chat session")
+      .choices([...REASONING_MODES])
+      .default("auto"),
   )
   .option("--dont-fetch-catalog", "Skip fetching the model catalog", false)
   .option("-y, --yes", "Assume 'yes' as answer to all CLI prompts");
@@ -234,6 +249,7 @@ chatCommand.action(async (model, options: ChatCommandOptions) => {
       {
         stats: options.stats,
         ttl,
+        reasoningMode: options.reasoning,
       },
       logger,
       llm,
@@ -251,6 +267,7 @@ chatCommand.action(async (model, options: ChatCommandOptions) => {
     await handleNonInteractiveChat(llm, chat, providedPrompt, logger, {
       stats: options.stats,
       ttl,
+      reasoningMode: options.reasoning,
     });
   } else {
     logger.error("No prompt provided for non-interactive chat.");

--- a/src/subcommands/chat/react/Chat.tsx
+++ b/src/subcommands/chat/react/Chat.tsx
@@ -197,6 +197,15 @@ export const ChatComponent = React.memo(
       activeReasoningMode,
       shouldFetchModelCatalog,
     ]);
+    const commandRequiresArgumentsFromSuggestions = useCallback(
+      (commandName: string): boolean => {
+        const command = commandHandler
+          .list()
+          .find(cmd => cmd.name.toLowerCase() === commandName.toLowerCase());
+        return command?.requireArgumentsFromSuggestions === true;
+      },
+      [commandHandler],
+    );
 
     const slashCommandInputText = useMemo(() => {
       if (userInputState.segments.length === 0) {
@@ -238,7 +247,7 @@ export const ChatComponent = React.memo(
         .list()
         .find(cmd => cmd.name.toLowerCase() === commandName.toLowerCase());
 
-      if (command?.requireArgumentsFromSuggestions === true) {
+      if (commandRequiresArgumentsFromSuggestions(commandName)) {
         return true;
       }
 
@@ -249,7 +258,12 @@ export const ChatComponent = React.memo(
       }
 
       return hasArgumentPosition;
-    }, [commandHandler, slashCommandInputText, suggestions.length]);
+    }, [
+      commandHandler,
+      commandRequiresArgumentsFromSuggestions,
+      slashCommandInputText,
+      suggestions.length,
+    ]);
 
     // As selectedSuggestionIndex can be out of bounds due to changes in suggestions,
     // we normalize it here.
@@ -284,6 +298,7 @@ export const ChatComponent = React.memo(
       suggestions,
       suggestionsPerPage,
       setUserInputState,
+      commandRequiresArgumentsFromSuggestions,
     });
 
     const handleAbortPrediction = useCallback(() => {
@@ -706,12 +721,7 @@ export const ChatComponent = React.memo(
           onSuggestionsPageRight={handleSuggestionsPageRight}
           onSuggestionAccept={handleSuggestionAccept}
           onPaste={handlePaste}
-          commandRequiresArgumentsFromSuggestions={commandName => {
-            const command = commandHandler
-              .list()
-              .find(cmd => cmd.name.toLowerCase() === commandName.toLowerCase());
-            return command?.requireArgumentsFromSuggestions === true;
-          }}
+          commandRequiresArgumentsFromSuggestions={commandRequiresArgumentsFromSuggestions}
           selectedSuggestion={highlightedSuggestion ?? null}
           predictionSpinnerVisible={showPredictionSpinner}
         />

--- a/src/subcommands/chat/react/Chat.tsx
+++ b/src/subcommands/chat/react/Chat.tsx
@@ -299,6 +299,7 @@ export const ChatComponent = React.memo(
       suggestionsPerPage,
       setUserInputState,
       commandRequiresArgumentsFromSuggestions,
+      inputText: slashCommandInputText,
     });
 
     const handleAbortPrediction = useCallback(() => {

--- a/src/subcommands/chat/react/Chat.tsx
+++ b/src/subcommands/chat/react/Chat.tsx
@@ -667,11 +667,11 @@ export const ChatComponent = React.memo(
           onSuggestionsPageRight={handleSuggestionsPageRight}
           onSuggestionAccept={handleSuggestionAccept}
           onPaste={handlePaste}
-          commandHasSuggestions={commandName => {
+          commandRequiresArgumentsFromSuggestions={commandName => {
             const command = commandHandler
               .list()
               .find(cmd => cmd.name.toLowerCase() === commandName.toLowerCase());
-            return command !== undefined && command.buildSuggestions !== undefined;
+            return command?.requireArgumentsFromSuggestions === true;
           }}
           selectedSuggestion={highlightedSuggestion ?? null}
           predictionSpinnerVisible={showPredictionSpinner}

--- a/src/subcommands/chat/react/Chat.tsx
+++ b/src/subcommands/chat/react/Chat.tsx
@@ -4,6 +4,7 @@ import { type Chat, type LLM, type LLMPredictionStats, type LMStudioClient } fro
 import { Box, type DOMElement, useApp, Text } from "ink";
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { displayVerboseStats, getLargePastePlaceholderText } from "../util.js";
+import { reasoningModeToPredictionOpts, type ReasoningMode } from "../reasoning.js";
 import { ChatInput } from "./ChatInput.js";
 import { ChatMessagesList } from "./ChatMessagesList.js";
 import { ChatSuggestions } from "./ChatSuggestions.js";
@@ -41,6 +42,7 @@ interface ChatComponentProps {
   onExit: () => void;
   stats?: true;
   ttl?: number;
+  reasoningMode: ReasoningMode;
   shouldFetchModelCatalog?: boolean;
 }
 
@@ -59,6 +61,7 @@ export const ChatComponent = React.memo(
     onExit,
     stats,
     ttl,
+    reasoningMode,
     shouldFetchModelCatalog,
   }: ChatComponentProps) => {
     const { exit } = useApp();
@@ -89,6 +92,7 @@ export const ChatComponent = React.memo(
     const { isConfirmationActive, requestConfirmation, handleConfirmationResponse } =
       useConfirmationPrompt();
     const [promptProcessingProgress, setPromptProcessingProgress] = useState<number | null>(null);
+    const [activeReasoningMode, setActiveReasoningMode] = useState<ReasoningMode>(reasoningMode);
     const abortControllerRef = useRef<AbortController | null>(new AbortController());
     const downloadAbortControllerRef = useRef<AbortController | null>(null);
     const modelLoadingAbortControllerRef = useRef<AbortController | null>(null);
@@ -175,6 +179,8 @@ export const ChatComponent = React.memo(
         setModelLoadingProgress,
         modelLoadingAbortControllerRef,
         lastPredictionStatsRef,
+        reasoningMode: activeReasoningMode,
+        setReasoningMode: setActiveReasoningMode,
       });
       handler.setCommands(commands);
       return handler;
@@ -188,6 +194,7 @@ export const ChatComponent = React.memo(
       handleDownloadCommand,
       logInChat,
       logErrorInChat,
+      activeReasoningMode,
       shouldFetchModelCatalog,
     ]);
 
@@ -418,6 +425,7 @@ export const ChatComponent = React.memo(
           }),
         });
         const result = await llmRef.current.respond(chatRef.current, {
+          ...reasoningModeToPredictionOpts(activeReasoningMode),
           onFirstToken() {
             setShowPredictionSpinner(false);
             setPromptProcessingProgress(null);
@@ -615,8 +623,8 @@ export const ChatComponent = React.memo(
       requestConfirmation,
       client.llm,
       ttl,
+      activeReasoningMode,
     ]);
-
     return (
       <Box
         ref={rootUiRef}

--- a/src/subcommands/chat/react/Chat.tsx
+++ b/src/subcommands/chat/react/Chat.tsx
@@ -2,7 +2,7 @@ import { produce } from "@lmstudio/immer-with-plugins";
 import { type SimpleLogger } from "@lmstudio/lms-common";
 import { type Chat, type LLM, type LLMPredictionStats, type LMStudioClient } from "@lmstudio/sdk";
 import { Box, type DOMElement, useApp, Text } from "ink";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { displayVerboseStats, getLargePastePlaceholderText } from "../util.js";
 import { reasoningModeToPredictionOpts, type ReasoningMode } from "../reasoning.js";
 import { ChatInput } from "./ChatInput.js";
@@ -198,24 +198,63 @@ export const ChatComponent = React.memo(
       shouldFetchModelCatalog,
     ]);
 
-    const suggestions = useMemo<Suggestion[]>(() => {
+    const slashCommandInputText = useMemo(() => {
       if (userInputState.segments.length === 0) {
-        return [];
+        return "";
       }
-      const firstSegment = userInputState.segments[0];
-      const inputText = firstSegment.content;
+      return userInputState.segments[0]?.content ?? "";
+    }, [userInputState.segments]);
+
+    useEffect(() => {
+      setSelectedSuggestionIndex(null);
+    }, [slashCommandInputText]);
+
+    const suggestions = useMemo<Suggestion[]>(() => {
       return commandHandler.getSuggestions({
-        input: inputText,
-        shouldShowSuggestions: !isConfirmationActive && !isPredicting && inputText.startsWith("/"),
+        input: slashCommandInputText,
+        shouldShowSuggestions:
+          !isConfirmationActive && !isPredicting && slashCommandInputText.startsWith("/"),
       });
-    }, [commandHandler, isConfirmationActive, isPredicting, userInputState.segments]);
+    }, [commandHandler, isConfirmationActive, isPredicting, slashCommandInputText]);
 
     const suggestionsPerPage = useSuggestionsPerPage(messages);
     const areSuggestionsVisible = useMemo(() => suggestions.length > 0, [suggestions]);
+    const shouldAutoHighlightFirstSuggestion = useMemo(() => {
+      if (suggestions.length === 0) {
+        return false;
+      }
+
+      const inputWithTrimmedStart = slashCommandInputText.trimStart();
+      if (inputWithTrimmedStart.startsWith("/") === false) {
+        return false;
+      }
+
+      const firstWhitespaceIndex = inputWithTrimmedStart.indexOf(" ");
+      const hasArgumentPosition = firstWhitespaceIndex !== -1;
+      const commandName = hasArgumentPosition
+        ? inputWithTrimmedStart.slice(1, firstWhitespaceIndex)
+        : inputWithTrimmedStart.slice(1);
+      const command = commandHandler
+        .list()
+        .find(cmd => cmd.name.toLowerCase() === commandName.toLowerCase());
+
+      if (command?.requireArgumentsFromSuggestions === true) {
+        return true;
+      }
+
+      // Partial command names should keep command-completion behavior. Exact optional-argument
+      // commands such as /reasoning should only auto-highlight after the user enters a space.
+      if (command === undefined) {
+        return true;
+      }
+
+      return hasArgumentPosition;
+    }, [commandHandler, slashCommandInputText, suggestions.length]);
+
     // As selectedSuggestionIndex can be out of bounds due to changes in suggestions,
     // we normalize it here.
     const normalizedSelectedSuggestionIndex = useMemo(() => {
-      if (suggestions.length === 0) {
+      if (suggestions.length === 0 || shouldAutoHighlightFirstSuggestion === false) {
         return null;
       }
       if (selectedSuggestionIndex === null || selectedSuggestionIndex < 0) {
@@ -225,7 +264,7 @@ export const ChatComponent = React.memo(
         return suggestions.length - 1;
       }
       return selectedSuggestionIndex;
-    }, [selectedSuggestionIndex, suggestions.length]);
+    }, [selectedSuggestionIndex, shouldAutoHighlightFirstSuggestion, suggestions.length]);
     const highlightedSuggestion = useMemo(() => {
       if (normalizedSelectedSuggestionIndex === null) {
         return undefined;

--- a/src/subcommands/chat/react/Chat.tsx
+++ b/src/subcommands/chat/react/Chat.tsx
@@ -2,7 +2,7 @@ import { produce } from "@lmstudio/immer-with-plugins";
 import { type SimpleLogger } from "@lmstudio/lms-common";
 import { type Chat, type LLM, type LLMPredictionStats, type LMStudioClient } from "@lmstudio/sdk";
 import { Box, type DOMElement, useApp, Text } from "ink";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { displayVerboseStats, getLargePastePlaceholderText } from "../util.js";
 import { reasoningModeToPredictionOpts, type ReasoningMode } from "../reasoning.js";
 import { ChatInput } from "./ChatInput.js";
@@ -88,7 +88,10 @@ export const ChatComponent = React.memo(
       progress: number;
     } | null>(null);
     const lastPredictionStatsRef = useRef<LLMPredictionStats | null>(null);
-    const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState<number | null>(null);
+    const [selectedSuggestion, setSelectedSuggestion] = useState<{
+      inputText: string;
+      index: number;
+    } | null>(null);
     const { isConfirmationActive, requestConfirmation, handleConfirmationResponse } =
       useConfirmationPrompt();
     const [promptProcessingProgress, setPromptProcessingProgress] = useState<number | null>(null);
@@ -214,9 +217,27 @@ export const ChatComponent = React.memo(
       return userInputState.segments[0]?.content ?? "";
     }, [userInputState.segments]);
 
-    useEffect(() => {
-      setSelectedSuggestionIndex(null);
-    }, [slashCommandInputText]);
+    const selectedSuggestionIndex =
+      selectedSuggestion?.inputText === slashCommandInputText ? selectedSuggestion.index : null;
+    const setSelectedSuggestionIndex = useCallback(
+      (value: number | null | ((prev: number | null) => number | null)) => {
+        setSelectedSuggestion(previousSelectedSuggestion => {
+          const previousIndex =
+            previousSelectedSuggestion?.inputText === slashCommandInputText
+              ? previousSelectedSuggestion.index
+              : null;
+          const nextIndex = typeof value === "function" ? value(previousIndex) : value;
+          if (nextIndex === null) {
+            return null;
+          }
+          return {
+            inputText: slashCommandInputText,
+            index: nextIndex,
+          };
+        });
+      },
+      [slashCommandInputText],
+    );
 
     const suggestions = useMemo<Suggestion[]>(() => {
       return commandHandler.getSuggestions({

--- a/src/subcommands/chat/react/Chat.tsx
+++ b/src/subcommands/chat/react/Chat.tsx
@@ -299,7 +299,6 @@ export const ChatComponent = React.memo(
       suggestionsPerPage,
       setUserInputState,
       commandRequiresArgumentsFromSuggestions,
-      inputText: slashCommandInputText,
     });
 
     const handleAbortPrediction = useCallback(() => {

--- a/src/subcommands/chat/react/ChatInput.tsx
+++ b/src/subcommands/chat/react/ChatInput.tsx
@@ -34,7 +34,7 @@ interface ChatInputProps {
   onSuggestionsPageRight: () => void;
   onSuggestionAccept: () => void;
   onPaste: (content: string) => void;
-  commandHasSuggestions: (commandName: string) => boolean;
+  commandRequiresArgumentsFromSuggestions: (commandName: string) => boolean;
   selectedSuggestion?: { command: string; args: string[] } | null;
   predictionSpinnerVisible: boolean;
 }
@@ -60,7 +60,7 @@ export const ChatInput = ({
   onSuggestionsPageRight,
   onSuggestionAccept,
   onPaste,
-  commandHasSuggestions,
+  commandRequiresArgumentsFromSuggestions,
   selectedSuggestion,
   predictionSpinnerVisible,
 }: ChatInputProps) => {
@@ -139,12 +139,12 @@ export const ChatInput = ({
     }
 
     if (key.return === true) {
-      // Check if there's a selected suggestion for a command that has suggestions
+      // Check if there's a selected command suggestion that should expand into arguments.
       if (
         selectedSuggestion !== undefined &&
         selectedSuggestion !== null &&
         selectedSuggestion.args.length === 0 &&
-        commandHasSuggestions(selectedSuggestion.command)
+        commandRequiresArgumentsFromSuggestions(selectedSuggestion.command)
       ) {
         onSuggestionAccept();
         return;
@@ -152,10 +152,10 @@ export const ChatInput = ({
 
       const currentText = inputState.segments.map(segment => segment.content).join("");
 
-      // Check if input is a slash command without arguments that has suggestions
+      // Check if input is a slash command without arguments that should expand into suggestions.
       if (currentText.startsWith("/") && currentText.includes(" ") === false) {
         const commandName = currentText.slice(1);
-        if (commandHasSuggestions(commandName)) {
+        if (commandRequiresArgumentsFromSuggestions(commandName)) {
           setUserInputState(previousState =>
             insertTextAtCursor({ state: previousState, text: " " }),
           );

--- a/src/subcommands/chat/react/SlashCommandHandler.ts
+++ b/src/subcommands/chat/react/SlashCommandHandler.ts
@@ -29,6 +29,7 @@ export interface SlashCommand {
     context: SlashCommandExecutionContext,
   ) => void | Promise<void>;
   buildSuggestions?: (builderArgs: SlashCommandSuggestionBuilderArgs) => Suggestion[];
+  requireArgumentsFromSuggestions?: boolean;
 }
 
 export class SlashCommandHandler {

--- a/src/subcommands/chat/react/SlashCommandHandler.ts
+++ b/src/subcommands/chat/react/SlashCommandHandler.ts
@@ -187,6 +187,7 @@ export class SlashCommandHandler {
 
   private createCommandSuggestion(command: SlashCommand): Suggestion {
     const suggestion: Suggestion = {
+      completionKind: "command",
       command: command.name,
       args: [],
       priority: SlashCommandHandler.COMMAND_SUGGESTION_PRIORITY,

--- a/src/subcommands/chat/react/hooks.tsx
+++ b/src/subcommands/chat/react/hooks.tsx
@@ -534,7 +534,6 @@ export interface UseSuggestionHandlersOpts {
     value: ChatUserInputState | ((prev: ChatUserInputState) => ChatUserInputState),
   ) => void;
   commandRequiresArgumentsFromSuggestions: (commandName: string) => boolean;
-  inputText: string;
 }
 
 export function useSuggestionHandlers({
@@ -544,7 +543,6 @@ export function useSuggestionHandlers({
   suggestionsPerPage,
   setUserInputState,
   commandRequiresArgumentsFromSuggestions,
-  inputText,
 }: UseSuggestionHandlersOpts) {
   const handleSuggestionsUp = useCallback(() => {
     if (selectedSuggestionIndex === null) {
@@ -604,10 +602,9 @@ export function useSuggestionHandlers({
       acceptedSuggestion = selectedSuggestion;
       suggestionText = `/${selectedSuggestion.command} ${selectedSuggestion.args.join(" ")}`;
     } else {
-      const inputWithTrimmedStart = inputText.trimStart();
-      const exactCommandInput = inputWithTrimmedStart === `/${selectedSuggestion.command}`;
-      const shouldEnterRequiredArgumentMode =
-        exactCommandInput && commandRequiresArgumentsFromSuggestions(selectedSuggestion.command);
+      const shouldEnterRequiredArgumentMode = commandRequiresArgumentsFromSuggestions(
+        selectedSuggestion.command,
+      );
       suggestionText = `/${selectedSuggestion.command}${shouldEnterRequiredArgumentMode ? " " : ""}`;
     }
     setUserInputState((previousState: ChatUserInputState) =>
@@ -622,8 +619,6 @@ export function useSuggestionHandlers({
     suggestions,
     setUserInputState,
     commandRequiresArgumentsFromSuggestions,
-    inputText,
-    setSelectedSuggestionIndex,
   ]);
 
   return {

--- a/src/subcommands/chat/react/hooks.tsx
+++ b/src/subcommands/chat/react/hooks.tsx
@@ -534,6 +534,7 @@ export interface UseSuggestionHandlersOpts {
     value: ChatUserInputState | ((prev: ChatUserInputState) => ChatUserInputState),
   ) => void;
   commandRequiresArgumentsFromSuggestions: (commandName: string) => boolean;
+  inputText: string;
 }
 
 export function useSuggestionHandlers({
@@ -543,17 +544,20 @@ export function useSuggestionHandlers({
   suggestionsPerPage,
   setUserInputState,
   commandRequiresArgumentsFromSuggestions,
+  inputText,
 }: UseSuggestionHandlersOpts) {
   const handleSuggestionsUp = useCallback(() => {
     if (selectedSuggestionIndex === null) {
+      setSelectedSuggestionIndex(suggestions.length > 0 ? suggestions.length - 1 : null);
       return;
     }
     const nextIndex = Math.max(0, selectedSuggestionIndex - 1);
     setSelectedSuggestionIndex(nextIndex);
-  }, [selectedSuggestionIndex, setSelectedSuggestionIndex]);
+  }, [selectedSuggestionIndex, suggestions.length, setSelectedSuggestionIndex]);
 
   const handleSuggestionsDown = useCallback(() => {
     if (selectedSuggestionIndex === null) {
+      setSelectedSuggestionIndex(suggestions.length > 0 ? 0 : null);
       return;
     }
     const nextIndex = Math.min(suggestions.length - 1, selectedSuggestionIndex + 1);
@@ -594,15 +598,18 @@ export function useSuggestionHandlers({
 
     const { insertSuggestionAtCursor } = await import("./inputReducer.js");
 
-    const hasArguments = selectedSuggestion.args.length > 0;
-    const argumentsText = selectedSuggestion.args.join(" ");
-    const acceptedSuggestion = hasArguments ? selectedSuggestion : undefined;
-    const shouldAppendArgumentSpace =
-      hasArguments === false &&
-      commandRequiresArgumentsFromSuggestions(selectedSuggestion.command) === true;
-    const suggestionText = hasArguments
-      ? `/${selectedSuggestion.command} ${argumentsText}`
-      : `/${selectedSuggestion.command}${shouldAppendArgumentSpace ? " " : ""}`;
+    let acceptedSuggestion: Suggestion | undefined;
+    let suggestionText: string;
+    if (selectedSuggestion.completionKind === "argument") {
+      acceptedSuggestion = selectedSuggestion;
+      suggestionText = `/${selectedSuggestion.command} ${selectedSuggestion.args.join(" ")}`;
+    } else {
+      const inputWithTrimmedStart = inputText.trimStart();
+      const exactCommandInput = inputWithTrimmedStart === `/${selectedSuggestion.command}`;
+      const shouldEnterRequiredArgumentMode =
+        exactCommandInput && commandRequiresArgumentsFromSuggestions(selectedSuggestion.command);
+      suggestionText = `/${selectedSuggestion.command}${shouldEnterRequiredArgumentMode ? " " : ""}`;
+    }
     setUserInputState((previousState: ChatUserInputState) =>
       insertSuggestionAtCursor({
         state: previousState,
@@ -615,6 +622,8 @@ export function useSuggestionHandlers({
     suggestions,
     setUserInputState,
     commandRequiresArgumentsFromSuggestions,
+    inputText,
+    setSelectedSuggestionIndex,
   ]);
 
   return {

--- a/src/subcommands/chat/react/hooks.tsx
+++ b/src/subcommands/chat/react/hooks.tsx
@@ -533,6 +533,7 @@ export interface UseSuggestionHandlersOpts {
   setUserInputState: (
     value: ChatUserInputState | ((prev: ChatUserInputState) => ChatUserInputState),
   ) => void;
+  commandRequiresArgumentsFromSuggestions: (commandName: string) => boolean;
 }
 
 export function useSuggestionHandlers({
@@ -541,6 +542,7 @@ export function useSuggestionHandlers({
   suggestions,
   suggestionsPerPage,
   setUserInputState,
+  commandRequiresArgumentsFromSuggestions,
 }: UseSuggestionHandlersOpts) {
   const handleSuggestionsUp = useCallback(() => {
     if (selectedSuggestionIndex === null) {
@@ -595,10 +597,12 @@ export function useSuggestionHandlers({
     const hasArguments = selectedSuggestion.args.length > 0;
     const argumentsText = selectedSuggestion.args.join(" ");
     const acceptedSuggestion = hasArguments ? selectedSuggestion : undefined;
-    // Always add a space after the command (even without args) to trigger suggestions
+    const shouldAppendArgumentSpace =
+      hasArguments === false &&
+      commandRequiresArgumentsFromSuggestions(selectedSuggestion.command) === true;
     const suggestionText = hasArguments
       ? `/${selectedSuggestion.command} ${argumentsText}`
-      : `/${selectedSuggestion.command} `;
+      : `/${selectedSuggestion.command}${shouldAppendArgumentSpace ? " " : ""}`;
     setUserInputState((previousState: ChatUserInputState) =>
       insertSuggestionAtCursor({
         state: previousState,
@@ -606,7 +610,12 @@ export function useSuggestionHandlers({
         acceptedSuggestion,
       }),
     );
-  }, [selectedSuggestionIndex, suggestions, setUserInputState]);
+  }, [
+    selectedSuggestionIndex,
+    suggestions,
+    setUserInputState,
+    commandRequiresArgumentsFromSuggestions,
+  ]);
 
   return {
     handleSuggestionsUp,

--- a/src/subcommands/chat/react/inputReducer.test.ts
+++ b/src/subcommands/chat/react/inputReducer.test.ts
@@ -1031,6 +1031,7 @@ describe("chatInputStateReducers", () => {
     it("stores the accepted suggestion", () => {
       const initialState = createChatUserInputState([{ type: "text", content: "/mod" }], 0, 4);
       const acceptedSuggestion: Suggestion = {
+        completionKind: "argument",
         command: "model",
         args: ["owner/model"],
         priority: 1,
@@ -1048,6 +1049,7 @@ describe("chatInputStateReducers", () => {
 
     it("clears the accepted suggestion when accepting a command suggestion", () => {
       const acceptedSuggestion: Suggestion = {
+        completionKind: "argument",
         command: "model",
         args: ["owner/model"],
         priority: 1,
@@ -1069,6 +1071,7 @@ describe("chatInputStateReducers", () => {
 
     it("clears the accepted suggestion when text changes", () => {
       const acceptedSuggestion: Suggestion = {
+        completionKind: "argument",
         command: "model",
         args: ["owner/model"],
         priority: 1,

--- a/src/subcommands/chat/react/slashCommands.ts
+++ b/src/subcommands/chat/react/slashCommands.ts
@@ -78,6 +78,7 @@ export function createSlashCommands({
     {
       name: "model",
       description: "Load a model (type /model to see list)",
+      requireArgumentsFromSuggestions: true,
       handler: async (commandArguments, context) => {
         if (commandArguments.length === 0) {
           logInChat("Please specify a model to load. Type /model to see the list.");
@@ -231,6 +232,7 @@ export function createSlashCommands({
     {
       name: "download",
       description: "Download a model",
+      requireArgumentsFromSuggestions: true,
       handler: handleDownloadCommand,
       buildSuggestions: ({ argsInput, registerSuggestionMetadata }) => {
         if (shouldFetchModelCatalog !== true) {

--- a/src/subcommands/chat/react/slashCommands.ts
+++ b/src/subcommands/chat/react/slashCommands.ts
@@ -3,6 +3,7 @@ import { type LLM, type LLMPredictionStats, type LMStudioClient, Chat } from "@l
 import chalk from "chalk";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { displayVerboseStats } from "../util.js";
+import { isReasoningMode, REASONING_MODES, type ReasoningMode } from "../reasoning.js";
 import type {
   SlashCommand,
   SlashCommandExecutionContext,
@@ -31,6 +32,8 @@ export interface CreateSlashCommandsOpts {
   setModelLoadingProgress: Dispatch<SetStateAction<number | null>>;
   modelLoadingAbortControllerRef: RefObject<AbortController | null>;
   lastPredictionStatsRef: RefObject<LLMPredictionStats | null>;
+  reasoningMode: ReasoningMode;
+  setReasoningMode: Dispatch<SetStateAction<ReasoningMode>>;
 }
 
 export function createSlashCommands({
@@ -53,6 +56,8 @@ export function createSlashCommands({
   setModelLoadingProgress,
   modelLoadingAbortControllerRef,
   lastPredictionStatsRef,
+  reasoningMode,
+  setReasoningMode,
 }: CreateSlashCommandsOpts): SlashCommand[] {
   return [
     {
@@ -184,6 +189,43 @@ export function createSlashCommands({
           return;
         }
         displayVerboseStats(lastPredictionStatsRef.current, logInChat);
+      },
+    },
+    {
+      name: "reasoning",
+      description: "Set reasoning mode (auto, on, off)",
+      handler: async commandArguments => {
+        if (commandArguments.length === 0) {
+          logInChat(`Reasoning mode: ${reasoningMode}`);
+          return;
+        }
+        if (commandArguments.length !== 1) {
+          logErrorInChat("Usage: /reasoning auto|on|off");
+          return;
+        }
+
+        const requestedMode = commandArguments[0]?.toLowerCase();
+        if (requestedMode === undefined || isReasoningMode(requestedMode) === false) {
+          logErrorInChat("Usage: /reasoning auto|on|off");
+          return;
+        }
+
+        setReasoningMode(requestedMode);
+        logInChat(`Reasoning mode set to: ${requestedMode}`);
+      },
+      buildSuggestions: ({ argsInput, registerSuggestionMetadata }) => {
+        const normalizedFilter = argsInput.trim().toLowerCase();
+        return REASONING_MODES.filter(mode => mode.startsWith(normalizedFilter)).map(mode => {
+          const suggestion: Suggestion = {
+            command: "reasoning",
+            args: [mode],
+            priority: 1,
+          };
+          registerSuggestionMetadata(suggestion, {
+            label: `/reasoning ${mode}`,
+          });
+          return suggestion;
+        });
       },
     },
     {

--- a/src/subcommands/chat/react/slashCommands.ts
+++ b/src/subcommands/chat/react/slashCommands.ts
@@ -218,6 +218,7 @@ export function createSlashCommands({
         const normalizedFilter = argsInput.trim().toLowerCase();
         return REASONING_MODES.filter(mode => mode.startsWith(normalizedFilter)).map(mode => {
           const suggestion: Suggestion = {
+            completionKind: "argument",
             command: "reasoning",
             args: [mode],
             priority: 1,
@@ -251,6 +252,7 @@ export function createSlashCommands({
               });
         return filteredModels.map(model => {
           const suggestion: Suggestion = {
+            completionKind: "argument",
             command: "download",
             args: [`${model.owner}/${model.name}`],
             priority: model.staffPickedAt !== undefined ? 2 : 1,
@@ -337,6 +339,7 @@ function createModelSuggestion({
 }: CreateModelSuggestionOpts): Suggestion {
   const priority = modelState.isCurrent ? 3 : modelState.isLoaded ? 2 : 1;
   const suggestion: Suggestion = {
+    completionKind: "argument",
     command: "model",
     args: [modelState.modelKey],
     priority,

--- a/src/subcommands/chat/react/types.ts
+++ b/src/subcommands/chat/react/types.ts
@@ -52,6 +52,7 @@ export type SuggestionExecution =
     };
 
 export interface Suggestion {
+  completionKind: "command" | "argument";
   command: string;
   args: string[];
   priority: number;

--- a/src/subcommands/chat/reasoning.ts
+++ b/src/subcommands/chat/reasoning.ts
@@ -1,0 +1,20 @@
+export const REASONING_MODES = ["auto", "on", "off"] as const;
+
+export type ReasoningMode = (typeof REASONING_MODES)[number];
+
+export function isReasoningMode(value: string): value is ReasoningMode {
+  return REASONING_MODES.some(mode => mode === value);
+}
+
+export function reasoningModeToPredictionOpts(
+  reasoningMode: ReasoningMode,
+): { enableThinking?: boolean } {
+  switch (reasoningMode) {
+    case "auto":
+      return {};
+    case "on":
+      return { enableThinking: true };
+    case "off":
+      return { enableThinking: false };
+  }
+}

--- a/src/subcommands/chat/util.ts
+++ b/src/subcommands/chat/util.ts
@@ -2,6 +2,7 @@ import type { SimpleLogger } from "@lmstudio/lms-common";
 import { type Chat, type LLM, type LLMPredictionStats, type LMStudioClient } from "@lmstudio/sdk";
 import chalk from "chalk";
 import { Spinner } from "../../Spinner.js";
+import { reasoningModeToPredictionOpts, type ReasoningMode } from "./reasoning.js";
 import { type InkChatMessage } from "./react/types.js";
 
 export async function loadModelWithProgress(
@@ -91,12 +92,13 @@ export async function executePrediction(
   chat: Chat,
   input: string,
   controller?: AbortController,
+  reasoningMode: ReasoningMode = "auto",
 ): Promise<{ result: any; lastFragment: string }> {
   chat.append("user", input);
   const prediction = llmModel.respond(chat, {
+    ...reasoningModeToPredictionOpts(reasoningMode),
     signal: controller?.signal,
   });
-
   let lastFragment = "";
   for await (const fragment of prediction) {
     if (fragment.reasoningType === "reasoningStartTag") {


### PR DESCRIPTION
## Summary
- Add `lms chat --reasoning auto|on|off` for session-level reasoning control.
- Default `auto` leaves the SDK `enableThinking` value unset.
- `on` and `off` explicitly pass `enableThinking: true` / `false` to chat predictions.
- Add `/reasoning` in the interactive TUI to view or change the active session mode.

## Validation
- `npx turbo run build --filter=@lmstudio/lms-cli...`