### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here are some frequently used commands:
 - `lms status` - To check the status of LM Studio.
 - `lms server start` - To start the local API server.
 
-> **Tip:** LM Studio's local server is OpenAI-compatible. The same client `base_url` pattern also works with remote multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=lms&utm_content=readme) at `https://api.daoxe.com/v1`.
+> **Tip:** LM Studio's local server is OpenAI-compatible. The same client `base_url` pattern also works with remote multi-model gateways — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 - `lms server stop` - To stop the local API server.
 - `lms ls` - To list all downloaded models.
   - `lms ls --json` - To list all downloaded models in machine-readable JSON format.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Here are some frequently used commands:
 
 - `lms status` - To check the status of LM Studio.
 - `lms server start` - To start the local API server.
+
+> **Tip:** LM Studio's local server is OpenAI-compatible. The same client `base_url` pattern also works with remote multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=lms&utm_content=readme) at `https://api.daoxe.com/v1`.
 - `lms server stop` - To stop the local API server.
 - `lms ls` - To list all downloaded models.
   - `lms ls --json` - To list all downloaded models in machine-readable JSON format.


### PR DESCRIPTION
Clarify that the OpenAI client `base_url` pattern works with OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com/) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>