### PR TITLE
Update CLI drafter load options

### DIFF
--- a/src/subcommands/chat/getLLM.ts
+++ b/src/subcommands/chat/getLLM.ts
@@ -96,6 +96,7 @@ export async function maybeGetLLM(
     const lastLoadedIndexToPathMap = [...lastLoadedModels.entries()];
     const lastLoadedMap = new Map(lastLoadedIndexToPathMap.map(([index, path]) => [path, index]));
     const models = (await client.system.listDownloadedModels())
+      .filter(model => model.isDraftOnly !== true)
       .filter(model => model.architecture?.toLowerCase().includes("clip") !== true)
       .sort((a, b) => {
         const aIndex = lastLoadedMap.get(a.path) ?? lastLoadedMap.size + 1;

--- a/src/subcommands/chat/getLLM.ts
+++ b/src/subcommands/chat/getLLM.ts
@@ -96,7 +96,7 @@ export async function maybeGetLLM(
     const lastLoadedIndexToPathMap = [...lastLoadedModels.entries()];
     const lastLoadedMap = new Map(lastLoadedIndexToPathMap.map(([index, path]) => [path, index]));
     const models = (await client.system.listDownloadedModels())
-      .filter(model => model.isDraftOnly !== true)
+      .filter(model => model.type === "llm")
       .filter(model => model.architecture?.toLowerCase().includes("clip") !== true)
       .sort((a, b) => {
         const aIndex = lastLoadedMap.get(a.path) ?? lastLoadedMap.size + 1;

--- a/src/subcommands/chat/react/hooks.tsx
+++ b/src/subcommands/chat/react/hooks.tsx
@@ -136,7 +136,9 @@ export function useDownloadedModels(
         client.llm.listLoaded(),
         createDeviceNameResolver(client, logger),
       ]);
-      const downloadedModels = allDownloadedModels.filter(model => model.type === "llm");
+      const downloadedModels = allDownloadedModels.filter(
+        model => model.type === "llm" && model.isDraftOnly !== true,
+      );
       const loadedModelInfos = await Promise.all(
         loadedModels.map(async loadedModel => {
           const loadedModelInfo = await loadedModel.getModelInfo();

--- a/src/subcommands/chat/react/hooks.tsx
+++ b/src/subcommands/chat/react/hooks.tsx
@@ -136,9 +136,7 @@ export function useDownloadedModels(
         client.llm.listLoaded(),
         createDeviceNameResolver(client, logger),
       ]);
-      const downloadedModels = allDownloadedModels.filter(
-        model => model.type === "llm" && model.isDraftOnly !== true,
-      );
+      const downloadedModels = allDownloadedModels.filter(model => model.type === "llm");
       const loadedModelInfos = await Promise.all(
         loadedModels.map(async loadedModel => {
           const loadedModelInfo = await loadedModel.getModelInfo();

--- a/src/subcommands/list.test.ts
+++ b/src/subcommands/list.test.ts
@@ -1,0 +1,35 @@
+import { filterModelsForListCommand, type CliListModel } from "./listModelFilters.js";
+
+function cliListModel(type: CliListModel["type"]): CliListModel {
+  return { type };
+}
+
+describe("filterModelsForListCommand", () => {
+  it("returns all model types without domain filters", () => {
+    const models = [cliListModel("llm"), cliListModel("embedding"), cliListModel("drafter")];
+
+    expect(filterModelsForListCommand(models, {})).toEqual(models);
+  });
+
+  it("filters to drafters for lms ls --drafter", () => {
+    const drafterModel = cliListModel("drafter");
+
+    expect(
+      filterModelsForListCommand([cliListModel("llm"), cliListModel("embedding"), drafterModel], {
+        drafter: true,
+      }),
+    ).toEqual([drafterModel]);
+  });
+
+  it("combines drafter with other domain filters", () => {
+    const llmModel = cliListModel("llm");
+    const drafterModel = cliListModel("drafter");
+
+    expect(
+      filterModelsForListCommand([llmModel, cliListModel("embedding"), drafterModel], {
+        llm: true,
+        drafter: true,
+      }),
+    ).toEqual([llmModel, drafterModel]);
+  });
+});

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -229,6 +229,7 @@ type ListCommandOptions = OptionValues &
   LogLevelArgs & {
     llm?: boolean;
     embedding?: boolean;
+    drafter?: boolean;
     detailed?: boolean;
     variants?: boolean;
     json?: boolean;
@@ -246,6 +247,7 @@ const lsCommand = new Command<[], ListCommandOptions>()
   .argument("[modelKey]", "Show variants for the provided model key")
   .option("--llm", "Show only LLM models")
   .option("--embedding", "Show only embedding models")
+  .option("--drafter", "Show only drafter models")
   .option("--detailed", "[Deprecated] Show detailed view with grouping")
   .option("--variants", "Show variants for all models")
   .option("--json", "Outputs in JSON format to stdout");
@@ -261,6 +263,7 @@ lsCommand.action(async (modelKey, options: ListCommandOptions) => {
   const {
     llm = false,
     embedding = false,
+    drafter = false,
     detailed = false,
     variants: variantsOption = false,
     json = false,
@@ -287,7 +290,12 @@ lsCommand.action(async (modelKey, options: ListCommandOptions) => {
 
     const loadedModels = await listLoadedModels(client);
     const firstVariantType = variants[0]?.type;
-    const variantTitle = firstVariantType === "embedding" ? "EMBEDDING" : "LLM";
+    const variantTitle =
+      firstVariantType === "embedding"
+        ? "EMBEDDING"
+        : firstVariantType === "drafter"
+          ? "DRAFTER"
+          : "LLM";
 
     console.info();
     console.info(`Listing variants for ${modelKey}:`);
@@ -303,13 +311,16 @@ lsCommand.action(async (modelKey, options: ListCommandOptions) => {
   const originalModelsCount = allDownloadedModels.length;
 
   let filteredDownloadedModels = allDownloadedModels;
-  if (llm || embedding) {
+  if (llm || embedding || drafter) {
     const allowedTypes = new Set<string>();
     if (llm) {
       allowedTypes.add("llm");
     }
     if (embedding) {
       allowedTypes.add("embedding");
+    }
+    if (drafter) {
+      allowedTypes.add("drafter");
     }
     filteredDownloadedModels = allDownloadedModels.filter(model => allowedTypes.has(model.type));
   }
@@ -402,6 +413,18 @@ lsCommand.action(async (modelKey, options: ListCommandOptions) => {
       });
       console.info();
     }
+
+    const drafterModels = filteredDownloadedModels.filter(model => model.type === "drafter");
+    if (drafterModels.length > 0) {
+      printModelsWithVariantRows({
+        title: "DRAFTER",
+        baseModels: drafterModels,
+        loadedModels,
+        variantInfosByModelKey,
+        deviceNameResolver,
+      });
+      console.info();
+    }
     return;
   }
 
@@ -414,6 +437,12 @@ lsCommand.action(async (modelKey, options: ListCommandOptions) => {
   const embeddingModels = filteredDownloadedModels.filter(model => model.type === "embedding");
   if (embeddingModels.length > 0) {
     printDownloadedModelsTable("EMBEDDING", embeddingModels, loadedModels, deviceNameResolver);
+    console.info();
+  }
+
+  const drafterModels = filteredDownloadedModels.filter(model => model.type === "drafter");
+  if (drafterModels.length > 0) {
+    printDownloadedModelsTable("DRAFTER", drafterModels, loadedModels, deviceNameResolver);
     console.info();
   }
 });

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -306,7 +306,7 @@ lsCommand.action(async (modelKey, options: ListCommandOptions) => {
     return;
   }
 
-  const allDownloadedModels = await client.system.listDownloadedModels();
+  const allDownloadedModels = await client.system.listDownloadedModels({ includeDrafters: true });
   const loadedModels = await listLoadedModels(client);
 
   const originalModelsCount = allDownloadedModels.length;

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -13,6 +13,7 @@ import {
 import { formatSizeBytes1000 } from "../formatBytes.js";
 import { formatTimeLean } from "../formatElapsedTime.js";
 import { addLogLevelOptions, createLogger, type LogLevelArgs } from "../logLevel.js";
+import { filterModelsForListCommand } from "./listModelFilters.js";
 
 function loadedCheck(count: number) {
   if (count === 0) {
@@ -310,20 +311,11 @@ lsCommand.action(async (modelKey, options: ListCommandOptions) => {
 
   const originalModelsCount = allDownloadedModels.length;
 
-  let filteredDownloadedModels = allDownloadedModels;
-  if (llm || embedding || drafter) {
-    const allowedTypes = new Set<string>();
-    if (llm) {
-      allowedTypes.add("llm");
-    }
-    if (embedding) {
-      allowedTypes.add("embedding");
-    }
-    if (drafter) {
-      allowedTypes.add("drafter");
-    }
-    filteredDownloadedModels = allDownloadedModels.filter(model => allowedTypes.has(model.type));
-  }
+  const filteredDownloadedModels = filterModelsForListCommand(allDownloadedModels, {
+    llm,
+    embedding,
+    drafter,
+  });
 
   const filteredModelsCount = filteredDownloadedModels.length;
 

--- a/src/subcommands/listModelFilters.ts
+++ b/src/subcommands/listModelFilters.ts
@@ -1,0 +1,30 @@
+import { type ModelInfo } from "@lmstudio/sdk";
+
+export type CliListModelFilterOptions = {
+  llm?: boolean;
+  embedding?: boolean;
+  drafter?: boolean;
+};
+
+export type CliListModel = Pick<ModelInfo, "type">;
+
+export function filterModelsForListCommand<TModel extends CliListModel>(
+  models: Array<TModel>,
+  { llm = false, embedding = false, drafter = false }: CliListModelFilterOptions,
+): Array<TModel> {
+  if (llm === false && embedding === false && drafter === false) {
+    return models;
+  }
+
+  const allowedTypes = new Set<ModelInfo["type"]>();
+  if (llm) {
+    allowedTypes.add("llm");
+  }
+  if (embedding) {
+    allowedTypes.add("embedding");
+  }
+  if (drafter) {
+    allowedTypes.add("drafter");
+  }
+  return models.filter(model => allowedTypes.has(model.type));
+}

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -160,6 +160,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       speculativeDraftSimple: false,
       speculativeDraftDflash: false,
       speculativeDraftDspark: false,
+      speculativeDraftModel: false,
     });
   });
 

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -150,6 +150,68 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     });
   });
 
+  it("creates explicit full speculative decoding off config", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftOff: true,
+      }),
+    ).toEqual({
+      speculativeDraftMtp: false,
+      speculativeDraftSimple: false,
+      speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
+    });
+  });
+
+  it("rejects full speculative decoding off with draft modes", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftOff: true,
+        speculativeDraftSimple: true,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-simple");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftOff: true,
+        speculativeDraftDflash: true,
+        speculativeDraftModel: "test/dflash-draft",
+      }),
+    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-dflash");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftOff: true,
+        speculativeDraftDspark: true,
+        speculativeDraftModel: "test/dspark-draft",
+      }),
+    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-dspark");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftOff: true,
+        speculativeDraftMtp: true,
+      }),
+    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-mtp");
+  });
+
+  it("rejects full speculative decoding off with draft model or tuning flags", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftOff: true,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-model");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftOff: true,
+        speculativeDraftMaxTokens: 7,
+      }),
+    ).toThrow("--speculative-draft-off cannot be used with speculative draft tuning flags");
+  });
+
   it("rejects draft tuning flags without a draft type", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -37,7 +37,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     });
   });
 
-  it("creates Draft MTP load config", () => {
+  it("creates bundled Draft MTP load config", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMtp: true,
@@ -46,6 +46,35 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     ).toEqual({
       speculativeDraftMtp: true,
       speculativeDraftMaxTokens: 7,
+    });
+  });
+
+  it("creates path-backed Draft MTP load config", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftMtp: true,
+        speculativeDraftModel: "test/mtp-assistant",
+        speculativeDraftMaxTokens: 7,
+      }),
+    ).toEqual({
+      speculativeDraftMtp: true,
+      speculativeDraftModel: "test/mtp-assistant",
+      speculativeDraftMaxTokens: 7,
+    });
+  });
+
+  it("creates DFlash load config", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftDflash: true,
+        speculativeDraftModel: "test/dflash-draft",
+        speculativeDraftMinTokens: 2,
+      }),
+    ).toEqual({
+      speculativeDraftMtp: false,
+      speculativeDraftDflash: true,
+      speculativeDraftModel: "test/dflash-draft",
+      speculativeDraftMinTokens: 2,
     });
   });
 
@@ -64,16 +93,16 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMaxTokens: 7,
       }),
-    ).toThrow("--speculative-draft-simple or --speculative-draft-mtp");
+    ).toThrow("--speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash");
 
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMinContinueProbability: 0.25,
       }),
-    ).toThrow("--speculative-draft-simple or --speculative-draft-mtp");
+    ).toThrow("--speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash");
   });
 
-  it("rejects draft model without Draft Simple", () => {
+  it("rejects draft model without a draft type", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftModel: "test/draft",
@@ -89,7 +118,15 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     ).toThrow("--speculative-draft-simple requires --speculative-draft-model");
   });
 
-  it("rejects Draft MTP with Draft Simple", () => {
+  it("rejects DFlash without a draft model", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftDflash: true,
+      }),
+    ).toThrow("--speculative-draft-dflash requires --speculative-draft-model");
+  });
+
+  it("rejects multiple draft modes", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMtp: true,
@@ -97,15 +134,22 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
         speculativeDraftModel: "test/draft",
       }),
     ).toThrow("--speculative-draft-mtp and --speculative-draft-simple");
-  });
 
-  it("rejects Draft MTP with a draft model resource", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMtp: true,
+        speculativeDraftDflash: true,
         speculativeDraftModel: "test/draft",
       }),
-    ).toThrow("--speculative-draft-mtp cannot be combined with --speculative-draft-model");
+    ).toThrow("--speculative-draft-mtp and --speculative-draft-dflash");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftSimple: true,
+        speculativeDraftDflash: true,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--speculative-draft-simple and --speculative-draft-dflash");
   });
 
   it("rejects min draft tokens greater than max draft tokens", () => {

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -15,6 +15,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       speculativeDraftMtp: false,
       speculativeDraftSimple: true,
       speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
       speculativeDraftModel: "test/draft",
     });
   });
@@ -32,6 +33,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       speculativeDraftMtp: false,
       speculativeDraftSimple: true,
       speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
       speculativeDraftModel: "test/draft",
       speculativeDraftMaxTokens: 7,
       speculativeDraftMinTokens: 2,
@@ -49,6 +51,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       speculativeDraftMtp: true,
       speculativeDraftSimple: false,
       speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
       speculativeDraftMaxTokens: 7,
     });
   });
@@ -64,6 +67,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       speculativeDraftMtp: true,
       speculativeDraftSimple: false,
       speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
       speculativeDraftModel: "test/mtp-assistant",
       speculativeDraftMaxTokens: 7,
     });
@@ -80,7 +84,25 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       speculativeDraftMtp: false,
       speculativeDraftSimple: false,
       speculativeDraftDflash: true,
+      speculativeDraftDspark: false,
       speculativeDraftModel: "test/dflash-draft",
+      speculativeDraftMinTokens: 2,
+    });
+  });
+
+  it("creates DSpark load config", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftDspark: true,
+        speculativeDraftModel: "test/dspark-draft",
+        speculativeDraftMinTokens: 2,
+      }),
+    ).toEqual({
+      speculativeDraftMtp: false,
+      speculativeDraftSimple: false,
+      speculativeDraftDflash: false,
+      speculativeDraftDspark: true,
+      speculativeDraftModel: "test/dspark-draft",
       speculativeDraftMinTokens: 2,
     });
   });
@@ -100,13 +122,17 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMaxTokens: 7,
       }),
-    ).toThrow("--speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash");
+    ).toThrow(
+      "--speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark",
+    );
 
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMinContinueProbability: 0.25,
       }),
-    ).toThrow("--speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash");
+    ).toThrow(
+      "--speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark",
+    );
   });
 
   it("rejects draft model without a draft type", () => {
@@ -133,6 +159,14 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     ).toThrow("--speculative-draft-dflash requires --speculative-draft-model");
   });
 
+  it("rejects DSpark without a draft model", () => {
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftDspark: true,
+      }),
+    ).toThrow("--speculative-draft-dspark requires --speculative-draft-model");
+  });
+
   it("rejects multiple draft modes", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
@@ -157,6 +191,14 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
         speculativeDraftModel: "test/draft",
       }),
     ).toThrow("--speculative-draft-simple and --speculative-draft-dflash");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftDflash: true,
+        speculativeDraftDspark: true,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--speculative-draft-dflash and --speculative-draft-dspark");
   });
 
   it("rejects min draft tokens greater than max draft tokens", () => {

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -1,4 +1,37 @@
 import { resolveCliSpeculativeDecodingLoadConfig } from "./loadSpeculativeDecoding.js";
+import { resolveExactDrafterLoadTarget, type CliLoadTargetModel } from "./loadTargetResolution.js";
+
+function cliModel(type: CliLoadTargetModel["type"], modelKey: string): CliLoadTargetModel {
+  return { type, modelKey };
+}
+
+describe("resolveExactDrafterLoadTarget", () => {
+  it("prefers exact standalone matches over exact drafter matches", () => {
+    const standaloneModel = cliModel("llm", "test/main");
+    const drafterModel = cliModel("drafter", "test/main");
+
+    expect(
+      resolveExactDrafterLoadTarget({
+        modelKey: "test/main",
+        standaloneModels: [standaloneModel],
+        allDownloadedModels: [standaloneModel, drafterModel],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("selects exact drafter matches before fuzzy standalone matching", () => {
+    const fuzzyStandaloneModel = cliModel("llm", "test/main-dflash-compatible");
+    const drafterModel = cliModel("drafter", "test/main-dflash");
+
+    expect(
+      resolveExactDrafterLoadTarget({
+        modelKey: "test/main-dflash",
+        standaloneModels: [fuzzyStandaloneModel],
+        allDownloadedModels: [fuzzyStandaloneModel, drafterModel],
+      }),
+    ).toBe(drafterModel);
+  });
+});
 
 describe("resolveCliSpeculativeDecodingLoadConfig", () => {
   it("omits speculative decoding when no speculative flags are provided", () => {

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -38,17 +38,13 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     expect(resolveCliSpeculativeDecodingLoadConfig({})).toEqual({});
   });
 
-  it("creates flat draft-model load config", () => {
+  it("creates inferred external drafter load config from the preferred --drafter flag", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftSimple: true,
-        speculativeDraftModel: "test/draft",
+        drafter: "test/draft",
       }),
     ).toEqual({
       speculativeDraftMtp: false,
-      speculativeDraftSimple: true,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
       speculativeDraftModel: "test/draft",
     });
   });
@@ -56,17 +52,13 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
   it("includes optional shared draft tuning settings", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftSimple: true,
-        speculativeDraftModel: "test/draft",
+        drafter: "test/draft",
         speculativeDraftMaxTokens: 7,
         speculativeDraftMinTokens: 2,
         speculativeDraftMinContinueProbability: 0.25,
       }),
     ).toEqual({
       speculativeDraftMtp: false,
-      speculativeDraftSimple: true,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
       speculativeDraftModel: "test/draft",
       speculativeDraftMaxTokens: 7,
       speculativeDraftMinTokens: 2,
@@ -74,22 +66,31 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     });
   });
 
-  it("creates bundled Draft MTP load config", () => {
+  it("creates bundled Draft MTP load config from the preferred --mtp flag", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftMtp: true,
+        mtp: true,
         speculativeDraftMaxTokens: 7,
       }),
     ).toEqual({
       speculativeDraftMtp: true,
-      speculativeDraftSimple: false,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
       speculativeDraftMaxTokens: 7,
     });
   });
 
-  it("creates path-backed Draft MTP load config", () => {
+  it("keeps legacy Draft Simple syntax accepted as external drafter config", () => {
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
+        speculativeDraftSimple: true,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toEqual({
+      speculativeDraftMtp: false,
+      speculativeDraftModel: "test/draft",
+    });
+  });
+
+  it("keeps legacy path-backed Draft MTP syntax accepted as inferred external drafter config", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMtp: true,
@@ -97,50 +98,23 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
         speculativeDraftMaxTokens: 7,
       }),
     ).toEqual({
-      speculativeDraftMtp: true,
-      speculativeDraftSimple: false,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
+      speculativeDraftMtp: false,
       speculativeDraftModel: "test/mtp-assistant",
       speculativeDraftMaxTokens: 7,
     });
   });
 
-  it("creates DFlash load config", () => {
+  it("keeps legacy bundled Draft MTP syntax accepted", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftDflash: true,
-        speculativeDraftModel: "test/dflash-draft",
-        speculativeDraftMinTokens: 2,
+        speculativeDraftMtp: true,
       }),
     ).toEqual({
-      speculativeDraftMtp: false,
-      speculativeDraftSimple: false,
-      speculativeDraftDflash: true,
-      speculativeDraftDspark: false,
-      speculativeDraftModel: "test/dflash-draft",
-      speculativeDraftMinTokens: 2,
+      speculativeDraftMtp: true,
     });
   });
 
-  it("creates DSpark load config", () => {
-    expect(
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftDspark: true,
-        speculativeDraftModel: "test/dspark-draft",
-        speculativeDraftMinTokens: 2,
-      }),
-    ).toEqual({
-      speculativeDraftMtp: false,
-      speculativeDraftSimple: false,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: true,
-      speculativeDraftModel: "test/dspark-draft",
-      speculativeDraftMinTokens: 2,
-    });
-  });
-
-  it("creates explicit Draft MTP off config", () => {
+  it("creates explicit Draft MTP off config from the legacy narrow off flag", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMtp: false,
@@ -153,155 +127,109 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
   it("creates explicit full speculative decoding off config", () => {
     expect(
       resolveCliSpeculativeDecodingLoadConfig({
+        drafter: false,
+      }),
+    ).toEqual({
+      speculativeDraftMtp: false,
+      speculativeDraftSimple: false,
+      speculativeDraftModel: false,
+    });
+
+    expect(
+      resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftOff: true,
       }),
     ).toEqual({
       speculativeDraftMtp: false,
       speculativeDraftSimple: false,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
       speculativeDraftModel: false,
     });
   });
 
-  it("rejects full speculative decoding off with draft modes", () => {
+  it("rejects full speculative decoding off with active speculative decoding flags", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftOff: true,
+        drafter: false,
+        mtp: true,
+      }),
+    ).toThrow("--no-drafter cannot be used with --mtp");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        drafter: false,
+        speculativeDraftModel: "test/draft",
+      }),
+    ).toThrow("--no-drafter cannot be used with --drafter");
+
+    expect(() =>
+      resolveCliSpeculativeDecodingLoadConfig({
+        drafter: false,
         speculativeDraftSimple: true,
-        speculativeDraftModel: "test/draft",
       }),
-    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-simple");
-
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftOff: true,
-        speculativeDraftDflash: true,
-        speculativeDraftModel: "test/dflash-draft",
-      }),
-    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-dflash");
-
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftOff: true,
-        speculativeDraftDspark: true,
-        speculativeDraftModel: "test/dspark-draft",
-      }),
-    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-dspark");
-
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftOff: true,
-        speculativeDraftMtp: true,
-      }),
-    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-mtp");
+    ).toThrow("--no-drafter cannot be used with --speculative-draft-simple");
   });
 
-  it("rejects full speculative decoding off with draft model or tuning flags", () => {
+  it("rejects full speculative decoding off with tuning flags", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftOff: true,
-        speculativeDraftModel: "test/draft",
-      }),
-    ).toThrow("--speculative-draft-off cannot be used with --speculative-draft-model");
-
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftOff: true,
+        drafter: false,
         speculativeDraftMaxTokens: 7,
       }),
-    ).toThrow("--speculative-draft-off cannot be used with speculative draft tuning flags");
+    ).toThrow("--no-drafter cannot be used with speculative draft tuning flags");
   });
 
-  it("rejects draft tuning flags without a draft type", () => {
+  it("rejects draft tuning flags without a draft source", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMaxTokens: 7,
       }),
-    ).toThrow(
-      "--speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark",
-    );
+    ).toThrow("speculative draft tuning flags require --drafter or --mtp");
 
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftMinContinueProbability: 0.25,
       }),
-    ).toThrow(
-      "--speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark",
-    );
+    ).toThrow("speculative draft tuning flags require --drafter or --mtp");
   });
 
-  it("rejects draft model without a draft type", () => {
+  it("rejects an empty draft model", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftModel: "test/draft",
+        drafter: "",
       }),
-    ).toThrow("--speculative-draft-model requires --speculative-draft-simple");
+    ).toThrow("--drafter must not be empty");
   });
 
-  it("rejects Draft Simple without a draft model", () => {
+  it("rejects legacy Draft Simple without a draft model", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
         speculativeDraftSimple: true,
       }),
-    ).toThrow("--speculative-draft-simple requires --speculative-draft-model");
+    ).toThrow("--speculative-draft-simple requires --drafter");
   });
 
-  it("rejects DFlash without a draft model", () => {
+  it("rejects conflicting preferred bundled MTP and external drafter flags", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftDflash: true,
+        mtp: true,
+        drafter: "test/draft",
       }),
-    ).toThrow("--speculative-draft-dflash requires --speculative-draft-model");
+    ).toThrow("--mtp cannot be used with --drafter");
   });
 
-  it("rejects DSpark without a draft model", () => {
+  it("rejects preferred and legacy draft model aliases together", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftDspark: true,
+        drafter: "test/draft",
+        speculativeDraftModel: "test/legacy-draft",
       }),
-    ).toThrow("--speculative-draft-dspark requires --speculative-draft-model");
-  });
-
-  it("rejects multiple draft modes", () => {
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftMtp: true,
-        speculativeDraftSimple: true,
-        speculativeDraftModel: "test/draft",
-      }),
-    ).toThrow("--speculative-draft-mtp and --speculative-draft-simple");
-
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftMtp: true,
-        speculativeDraftDflash: true,
-        speculativeDraftModel: "test/draft",
-      }),
-    ).toThrow("--speculative-draft-mtp and --speculative-draft-dflash");
-
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftSimple: true,
-        speculativeDraftDflash: true,
-        speculativeDraftModel: "test/draft",
-      }),
-    ).toThrow("--speculative-draft-simple and --speculative-draft-dflash");
-
-    expect(() =>
-      resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftDflash: true,
-        speculativeDraftDspark: true,
-        speculativeDraftModel: "test/draft",
-      }),
-    ).toThrow("--speculative-draft-dflash and --speculative-draft-dspark");
+    ).toThrow("--drafter cannot be used with --speculative-draft-model");
   });
 
   it("rejects min draft tokens greater than max draft tokens", () => {
     expect(() =>
       resolveCliSpeculativeDecodingLoadConfig({
-        speculativeDraftSimple: true,
-        speculativeDraftModel: "test/draft",
+        drafter: "test/draft",
         speculativeDraftMaxTokens: 2,
         speculativeDraftMinTokens: 7,
       }),

--- a/src/subcommands/load.test.ts
+++ b/src/subcommands/load.test.ts
@@ -14,6 +14,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     ).toEqual({
       speculativeDraftMtp: false,
       speculativeDraftSimple: true,
+      speculativeDraftDflash: false,
       speculativeDraftModel: "test/draft",
     });
   });
@@ -30,6 +31,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
     ).toEqual({
       speculativeDraftMtp: false,
       speculativeDraftSimple: true,
+      speculativeDraftDflash: false,
       speculativeDraftModel: "test/draft",
       speculativeDraftMaxTokens: 7,
       speculativeDraftMinTokens: 2,
@@ -45,6 +47,8 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       }),
     ).toEqual({
       speculativeDraftMtp: true,
+      speculativeDraftSimple: false,
+      speculativeDraftDflash: false,
       speculativeDraftMaxTokens: 7,
     });
   });
@@ -58,6 +62,8 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       }),
     ).toEqual({
       speculativeDraftMtp: true,
+      speculativeDraftSimple: false,
+      speculativeDraftDflash: false,
       speculativeDraftModel: "test/mtp-assistant",
       speculativeDraftMaxTokens: 7,
     });
@@ -72,6 +78,7 @@ describe("resolveCliSpeculativeDecodingLoadConfig", () => {
       }),
     ).toEqual({
       speculativeDraftMtp: false,
+      speculativeDraftSimple: false,
       speculativeDraftDflash: true,
       speculativeDraftModel: "test/dflash-draft",
       speculativeDraftMinTokens: 2,

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -84,7 +84,7 @@ function assertSpeculativeDecodingSupportedForCliModel({
     loadConfig.speculativeDraftMaxTokens !== undefined ||
     loadConfig.speculativeDraftMinTokens !== undefined ||
     loadConfig.speculativeDraftMinContinueProbability !== undefined;
-  if (!hasSpeculativeDecodingLoadConfig || model.type !== "embedding") {
+  if (!hasSpeculativeDecodingLoadConfig || model.type === "llm") {
     return;
   }
 
@@ -337,8 +337,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   );
   logger.debug(`Last loaded map loaded with ${lastLoadedMap.size} models.`);
 
-  const models = (await client.system.listDownloadedModels())
-    .filter(model => model.isDraftOnly !== true)
+  const allDownloadedModels = (await client.system.listDownloadedModels())
     .filter(model => model.architecture?.toLowerCase().includes("clip") !== true)
     .filter(model => (local ? model.deviceIdentifier === null : true))
     .sort((a, b) => {
@@ -346,6 +345,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
       const bIndex = lastLoadedMap.get(b.modelKey) ?? lastLoadedMap.size + 1;
       return aIndex < bIndex ? -1 : aIndex > bIndex ? 1 : 0;
     });
+  const models = allDownloadedModels.filter(model => model.type !== "drafter");
 
   if (exact) {
     if (modelKey === undefined) {
@@ -362,7 +362,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     }
     // In this case, we expect a model path and not a model key
     const modelPath = modelKey;
-    const model = models.find(model => model.path === modelPath);
+    const model = allDownloadedModels.find(model => model.path === modelPath);
     if (model === undefined) {
       if (models.length === 0) {
         logger.errorWithoutPrefix(
@@ -410,7 +410,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     if (estimateOnly === true) {
       assertSpeculativeDecodingSupportedForCliModel({ model, loadConfig, logger });
       const estimate = await (
-        model.type === "llm" ? client.llm : client.embedding
+        model.type === "embedding" ? client.embedding : client.llm
       ).estimateResourcesUsage(model.modelKey, loadConfig, {
         deviceIdentifier: model.deviceIdentifier,
       });
@@ -434,6 +434,13 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   }
 
   const modelKeys = models.map(model => model.modelKey);
+  const normalizedModelKey = modelKey?.toLowerCase();
+  const exactDrafterModel =
+    normalizedModelKey === undefined
+      ? undefined
+      : allDownloadedModels.find(
+          model => model.type === "drafter" && model.modelKey.toLowerCase() === normalizedModelKey,
+        );
 
   const initialFilteredModels = fuzzy.filter(modelKey ?? "", modelKeys);
   logger.debug("Initial filtered models length:", initialFilteredModels.length);
@@ -442,25 +449,28 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   let deferToPreferredDevice = false;
   if (yes) {
     if (initialFilteredModels.length === 0) {
-      logger.errorWithoutPrefix(
-        makeTitledPrettyError(
-          "Model not found",
-          text`
-            No model found that matches model key "${chalk.yellow(modelKey)}".
+      if (exactDrafterModel !== undefined) {
+        model = exactDrafterModel;
+      } else {
+        logger.errorWithoutPrefix(
+          makeTitledPrettyError(
+            "Model not found",
+            text`
+              No model found that matches model key "${chalk.yellow(modelKey)}".
 
-            To see a list of all downloaded models, run:
+              To see a list of all downloaded models, run:
 
-                ${chalk.yellow("lms ls")}
+                  ${chalk.yellow("lms ls")}
 
-            To select a model interactively, remove the ${chalk.yellow("--yes")} flag:
+              To select a model interactively, remove the ${chalk.yellow("--yes")} flag:
 
-                lms load
-          `,
-        ).message,
-      );
-      process.exit(1);
-    }
-    if (initialFilteredModels.length > 1) {
+                  lms load
+            `,
+          ).message,
+        );
+        process.exit(1);
+      }
+    } else if (initialFilteredModels.length > 1) {
       const matchingModels = initialFilteredModels.map(option => models[option.index]);
       const hasSameDeviceDuplicates = hasDuplicatesOnSameDevice(matchingModels);
       if (hasSameDeviceDuplicates) {
@@ -487,21 +497,25 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
         deviceNameResolver,
       });
     } else if (initialFilteredModels.length === 0) {
-      console.info(
-        chalk.red(text`
-          ! Cannot find a model matching the provided model key (${chalk.yellow(modelKey)}). Please
-          select one from the list below.
-        `),
-      );
-      modelKey = "";
-      model = await selectModel({
-        models,
-        modelKeys,
-        initialSearch: modelKey,
-        leaveEmptyLines: 5,
-        estimateOnly,
-        deviceNameResolver,
-      });
+      if (exactDrafterModel !== undefined) {
+        model = exactDrafterModel;
+      } else {
+        console.info(
+          chalk.red(text`
+            ! Cannot find a model matching the provided model key (${chalk.yellow(modelKey)}). Please
+            select one from the list below.
+          `),
+        );
+        modelKey = "";
+        model = await selectModel({
+          models,
+          modelKeys,
+          initialSearch: modelKey,
+          leaveEmptyLines: 5,
+          estimateOnly,
+          deviceNameResolver,
+        });
+      }
     } else if (initialFilteredModels.length === 1) {
       model = models[initialFilteredModels[0].index];
       // console.info(
@@ -538,7 +552,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   if (estimateOnly === true) {
     assertSpeculativeDecodingSupportedForCliModel({ model, loadConfig, logger });
     const estimate = await (
-      model.type === "llm" ? client.llm : client.embedding
+      model.type === "embedding" ? client.embedding : client.llm
     ).estimateResourcesUsage(model.modelKey, loadConfig, {
       deviceIdentifier: deferToPreferredDevice ? undefined : model.deviceIdentifier,
     });

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -26,6 +26,7 @@ import { Spinner } from "../Spinner.js";
 import { createRefinedNumberParser } from "../types/refinedNumber.js";
 import { fuzzyHighlightOptions, searchTheme } from "../inquirerTheme.js";
 import { resolveCliSpeculativeDecodingLoadConfig } from "./loadSpeculativeDecoding.js";
+import { resolveExactDrafterLoadTarget } from "./loadTargetResolution.js";
 
 const gpuOptionParser = (str: string): number => {
   str = str.trim().toLowerCase();
@@ -434,17 +435,11 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   }
 
   const modelKeys = models.map(model => model.modelKey);
-  const normalizedModelKey = modelKey?.toLowerCase();
-  const exactStandaloneModel =
-    normalizedModelKey === undefined
-      ? undefined
-      : models.find(model => model.modelKey.toLowerCase() === normalizedModelKey);
-  const exactDrafterModel =
-    normalizedModelKey === undefined || exactStandaloneModel !== undefined
-      ? undefined
-      : allDownloadedModels.find(
-          model => model.type === "drafter" && model.modelKey.toLowerCase() === normalizedModelKey,
-        );
+  const exactDrafterModel = resolveExactDrafterLoadTarget({
+    modelKey,
+    standaloneModels: models,
+    allDownloadedModels,
+  });
 
   const initialFilteredModels = fuzzy.filter(modelKey ?? "", modelKeys);
   logger.debug("Initial filtered models length:", initialFilteredModels.length);

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -53,6 +53,7 @@ type LoadCommandOptions = OptionValues &
     parallel?: number;
     speculativeDraftMtp?: boolean;
     speculativeDraftSimple?: boolean;
+    speculativeDraftDflash?: boolean;
     speculativeDraftModel?: string;
     speculativeDraftMaxTokens?: number;
     speculativeDraftMinTokens?: number;
@@ -76,6 +77,7 @@ function assertSpeculativeDecodingSupportedForCliModel({
   const hasSpeculativeDecodingLoadConfig =
     loadConfig.speculativeDraftMtp !== undefined ||
     loadConfig.speculativeDraftSimple !== undefined ||
+    loadConfig.speculativeDraftDflash !== undefined ||
     loadConfig.speculativeDraftModel !== undefined ||
     loadConfig.speculativeDraftMaxTokens !== undefined ||
     loadConfig.speculativeDraftMinTokens !== undefined ||
@@ -185,9 +187,18 @@ const loadCommand = new Command<[], LoadCommandOptions>()
   )
   .addOption(
     new Option(
+      "--speculative-draft-dflash",
+      text`
+        Enable load-time DFlash speculative decoding using --speculative-draft-model.
+      `,
+    ),
+  )
+  .addOption(
+    new Option(
       "--speculative-draft-model <model>",
       text`
-        Draft model resource to use with --speculative-draft-simple.
+        Draft model resource to use with --speculative-draft-simple,
+        --speculative-draft-dflash, or path-backed --speculative-draft-mtp.
       `,
     ),
   )
@@ -196,7 +207,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-max-tokens <count>",
       text`
         Maximum number of draft tokens to generate per speculative decoding step. Requires
-        --speculative-draft-simple or --speculative-draft-mtp.
+        --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 1 })),
   )
@@ -205,7 +216,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-min-tokens <count>",
       text`
         Minimum draft length to consider for speculative decoding. Requires
-        --speculative-draft-simple or --speculative-draft-mtp.
+        --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 0 })),
   )
@@ -214,7 +225,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-min-continue-probability <probability>",
       text`
         Continue drafting while token probability is at or above this threshold. Requires
-        --speculative-draft-simple or --speculative-draft-mtp.
+        --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.
       `,
     ).argParser(createRefinedNumberParser({ min: 0, max: 1 })),
   )
@@ -268,6 +279,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     parallel: maxParallelPredictions,
     speculativeDraftMtp,
     speculativeDraftSimple,
+    speculativeDraftDflash,
     speculativeDraftModel,
     speculativeDraftMaxTokens,
     speculativeDraftMinTokens,
@@ -284,6 +296,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     ...resolveCliSpeculativeDecodingLoadConfig({
       speculativeDraftMtp,
       speculativeDraftSimple,
+      speculativeDraftDflash,
       speculativeDraftModel,
       speculativeDraftMaxTokens,
       speculativeDraftMinTokens,
@@ -309,6 +322,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   logger.debug(`Last loaded map loaded with ${lastLoadedMap.size} models.`);
 
   const models = (await client.system.listDownloadedModels())
+    .filter(model => model.isDraftOnly !== true)
     .filter(model => model.architecture?.toLowerCase().includes("clip") !== true)
     .filter(model => (local ? model.deviceIdentifier === null : true))
     .sort((a, b) => {

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -52,11 +52,11 @@ type LoadCommandOptions = OptionValues &
     gpu?: number;
     contextLength?: number;
     parallel?: number;
+    mtp?: boolean;
+    drafter?: string | false;
     speculativeDraftMtp?: boolean;
     speculativeDraftOff?: boolean;
     speculativeDraftSimple?: boolean;
-    speculativeDraftDflash?: boolean;
-    speculativeDraftDspark?: boolean;
     speculativeDraftModel?: string;
     speculativeDraftMaxTokens?: number;
     speculativeDraftMinTokens?: number;
@@ -80,8 +80,6 @@ function assertSpeculativeDecodingSupportedForCliModel({
   const hasSpeculativeDecodingLoadConfig =
     loadConfig.speculativeDraftMtp !== undefined ||
     loadConfig.speculativeDraftSimple !== undefined ||
-    loadConfig.speculativeDraftDflash !== undefined ||
-    loadConfig.speculativeDraftDspark !== undefined ||
     loadConfig.speculativeDraftModel !== undefined ||
     loadConfig.speculativeDraftMaxTokens !== undefined ||
     loadConfig.speculativeDraftMinTokens !== undefined ||
@@ -167,70 +165,52 @@ const loadCommand = new Command<[], LoadCommandOptions>()
   )
   .addOption(
     new Option(
-      "--speculative-draft-mtp",
+      "--mtp",
       text`
-        Enable load-time Draft MTP speculative decoding when supported by the model.
+        Enable load-time speculative decoding with bundled MTP heads when supported by the model.
       `,
     ).default(undefined),
   )
   .addOption(
     new Option(
-      "--no-speculative-draft-mtp",
+      "--drafter <model>",
       text`
-        Disable load-time Draft MTP speculative decoding only. Deprecated: use
-        --speculative-draft-off to disable all speculative decoding modes.
+        Drafter model resource to use for load-time speculative decoding.
       `,
-    ).default(undefined),
+    ),
   )
   .addOption(
     new Option(
-      "--speculative-draft-off",
+      "--no-drafter",
       text`
         Disable all load-time speculative decoding modes for this load.
       `,
     ),
   )
   .addOption(
+    new Option("--speculative-draft-mtp", "Legacy alias for --mtp.").default(undefined).hideHelp(),
+  )
+  .addOption(
+    new Option("--no-speculative-draft-mtp", "Legacy option to disable load-time bundled MTP only.")
+      .default(undefined)
+      .hideHelp(),
+  )
+  .addOption(new Option("--speculative-draft-off", "Legacy alias for --no-drafter.").hideHelp())
+  .addOption(
     new Option(
       "--speculative-draft-simple",
-      text`
-        Enable load-time Draft Simple speculative decoding using --speculative-draft-model.
-      `,
-    ),
+      "Legacy Draft Simple selector. Use --drafter instead.",
+    ).hideHelp(),
   )
   .addOption(
-    new Option(
-      "--speculative-draft-dflash",
-      text`
-        Enable load-time DFlash speculative decoding using --speculative-draft-model.
-      `,
-    ),
-  )
-  .addOption(
-    new Option(
-      "--speculative-draft-dspark",
-      text`
-        Enable load-time DSpark speculative decoding using --speculative-draft-model.
-      `,
-    ),
-  )
-  .addOption(
-    new Option(
-      "--speculative-draft-model <model>",
-      text`
-        Draft model resource to use with --speculative-draft-simple,
-        --speculative-draft-dflash, --speculative-draft-dspark, or path-backed
-        --speculative-draft-mtp.
-      `,
-    ),
+    new Option("--speculative-draft-model <model>", "Legacy alias for --drafter.").hideHelp(),
   )
   .addOption(
     new Option(
       "--speculative-draft-max-tokens <count>",
       text`
         Maximum number of draft tokens to generate per speculative decoding step. Requires
-        --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or
-        --speculative-draft-dspark.
+        --drafter or --mtp.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 1 })),
   )
@@ -238,9 +218,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
     new Option(
       "--speculative-draft-min-tokens <count>",
       text`
-        Minimum draft length to consider for speculative decoding. Requires
-        --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or
-        --speculative-draft-dspark.
+        Minimum draft length to consider for speculative decoding. Requires --drafter or --mtp.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 0 })),
   )
@@ -249,8 +227,7 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-min-continue-probability <probability>",
       text`
         Continue drafting while token probability is at or above this threshold. Requires
-        --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or
-        --speculative-draft-dspark.
+        --drafter or --mtp.
       `,
     ).argParser(createRefinedNumberParser({ min: 0, max: 1 })),
   )
@@ -302,11 +279,11 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     gpu,
     contextLength,
     parallel: maxParallelPredictions,
+    mtp,
+    drafter,
     speculativeDraftMtp,
     speculativeDraftOff,
     speculativeDraftSimple,
-    speculativeDraftDflash,
-    speculativeDraftDspark,
     speculativeDraftModel,
     speculativeDraftMaxTokens,
     speculativeDraftMinTokens,
@@ -321,11 +298,11 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     contextLength,
     maxParallelPredictions,
     ...resolveCliSpeculativeDecodingLoadConfig({
+      mtp,
+      drafter,
       speculativeDraftMtp,
       speculativeDraftOff,
       speculativeDraftSimple,
-      speculativeDraftDflash,
-      speculativeDraftDspark,
       speculativeDraftModel,
       speculativeDraftMaxTokens,
       speculativeDraftMinTokens,

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -54,6 +54,7 @@ type LoadCommandOptions = OptionValues &
     speculativeDraftMtp?: boolean;
     speculativeDraftSimple?: boolean;
     speculativeDraftDflash?: boolean;
+    speculativeDraftDspark?: boolean;
     speculativeDraftModel?: string;
     speculativeDraftMaxTokens?: number;
     speculativeDraftMinTokens?: number;
@@ -78,6 +79,7 @@ function assertSpeculativeDecodingSupportedForCliModel({
     loadConfig.speculativeDraftMtp !== undefined ||
     loadConfig.speculativeDraftSimple !== undefined ||
     loadConfig.speculativeDraftDflash !== undefined ||
+    loadConfig.speculativeDraftDspark !== undefined ||
     loadConfig.speculativeDraftModel !== undefined ||
     loadConfig.speculativeDraftMaxTokens !== undefined ||
     loadConfig.speculativeDraftMinTokens !== undefined ||
@@ -195,10 +197,19 @@ const loadCommand = new Command<[], LoadCommandOptions>()
   )
   .addOption(
     new Option(
+      "--speculative-draft-dspark",
+      text`
+        Enable load-time DSpark speculative decoding using --speculative-draft-model.
+      `,
+    ),
+  )
+  .addOption(
+    new Option(
       "--speculative-draft-model <model>",
       text`
         Draft model resource to use with --speculative-draft-simple,
-        --speculative-draft-dflash, or path-backed --speculative-draft-mtp.
+        --speculative-draft-dflash, --speculative-draft-dspark, or path-backed
+        --speculative-draft-mtp.
       `,
     ),
   )
@@ -207,7 +218,8 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-max-tokens <count>",
       text`
         Maximum number of draft tokens to generate per speculative decoding step. Requires
-        --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.
+        --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or
+        --speculative-draft-dspark.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 1 })),
   )
@@ -216,7 +228,8 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-min-tokens <count>",
       text`
         Minimum draft length to consider for speculative decoding. Requires
-        --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.
+        --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or
+        --speculative-draft-dspark.
       `,
     ).argParser(createRefinedNumberParser({ integer: true, min: 0 })),
   )
@@ -225,7 +238,8 @@ const loadCommand = new Command<[], LoadCommandOptions>()
       "--speculative-draft-min-continue-probability <probability>",
       text`
         Continue drafting while token probability is at or above this threshold. Requires
-        --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.
+        --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or
+        --speculative-draft-dspark.
       `,
     ).argParser(createRefinedNumberParser({ min: 0, max: 1 })),
   )
@@ -280,6 +294,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     speculativeDraftMtp,
     speculativeDraftSimple,
     speculativeDraftDflash,
+    speculativeDraftDspark,
     speculativeDraftModel,
     speculativeDraftMaxTokens,
     speculativeDraftMinTokens,
@@ -297,6 +312,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
       speculativeDraftMtp,
       speculativeDraftSimple,
       speculativeDraftDflash,
+      speculativeDraftDspark,
       speculativeDraftModel,
       speculativeDraftMaxTokens,
       speculativeDraftMinTokens,

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -176,9 +176,18 @@ const loadCommand = new Command<[], LoadCommandOptions>()
     new Option(
       "--no-speculative-draft-mtp",
       text`
-        Disable load-time Draft MTP speculative decoding.
+        Disable load-time Draft MTP speculative decoding only. Deprecated: use
+        --speculative-draft-off to disable all speculative decoding modes.
       `,
     ).default(undefined),
+  )
+  .addOption(
+    new Option(
+      "--speculative-draft-off",
+      text`
+        Disable all load-time speculative decoding modes for this load.
+      `,
+    ),
   )
   .addOption(
     new Option(

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -435,8 +435,12 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
 
   const modelKeys = models.map(model => model.modelKey);
   const normalizedModelKey = modelKey?.toLowerCase();
-  const exactDrafterModel =
+  const exactStandaloneModel =
     normalizedModelKey === undefined
+      ? undefined
+      : models.find(model => model.modelKey.toLowerCase() === normalizedModelKey);
+  const exactDrafterModel =
+    normalizedModelKey === undefined || exactStandaloneModel !== undefined
       ? undefined
       : allDownloadedModels.find(
           model => model.type === "drafter" && model.modelKey.toLowerCase() === normalizedModelKey,
@@ -448,14 +452,13 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   let model: ModelInfo;
   let deferToPreferredDevice = false;
   if (yes) {
-    if (initialFilteredModels.length === 0) {
-      if (exactDrafterModel !== undefined) {
-        model = exactDrafterModel;
-      } else {
-        logger.errorWithoutPrefix(
-          makeTitledPrettyError(
-            "Model not found",
-            text`
+    if (exactDrafterModel !== undefined) {
+      model = exactDrafterModel;
+    } else if (initialFilteredModels.length === 0) {
+      logger.errorWithoutPrefix(
+        makeTitledPrettyError(
+          "Model not found",
+          text`
               No model found that matches model key "${chalk.yellow(modelKey)}".
 
               To see a list of all downloaded models, run:
@@ -466,10 +469,9 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
 
                   lms load
             `,
-          ).message,
-        );
-        process.exit(1);
-      }
+        ).message,
+      );
+      process.exit(1);
     } else if (initialFilteredModels.length > 1) {
       const matchingModels = initialFilteredModels.map(option => models[option.index]);
       const hasSameDeviceDuplicates = hasDuplicatesOnSameDevice(matchingModels);
@@ -496,26 +498,24 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
         estimateOnly,
         deviceNameResolver,
       });
+    } else if (exactDrafterModel !== undefined) {
+      model = exactDrafterModel;
     } else if (initialFilteredModels.length === 0) {
-      if (exactDrafterModel !== undefined) {
-        model = exactDrafterModel;
-      } else {
-        console.info(
-          chalk.red(text`
+      console.info(
+        chalk.red(text`
             ! Cannot find a model matching the provided model key (${chalk.yellow(modelKey)}). Please
             select one from the list below.
           `),
-        );
-        modelKey = "";
-        model = await selectModel({
-          models,
-          modelKeys,
-          initialSearch: modelKey,
-          leaveEmptyLines: 5,
-          estimateOnly,
-          deviceNameResolver,
-        });
-      }
+      );
+      modelKey = "";
+      model = await selectModel({
+        models,
+        modelKeys,
+        initialSearch: modelKey,
+        leaveEmptyLines: 5,
+        estimateOnly,
+        deviceNameResolver,
+      });
     } else if (initialFilteredModels.length === 1) {
       model = models[initialFilteredModels[0].index];
       // console.info(

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -53,6 +53,7 @@ type LoadCommandOptions = OptionValues &
     contextLength?: number;
     parallel?: number;
     speculativeDraftMtp?: boolean;
+    speculativeDraftOff?: boolean;
     speculativeDraftSimple?: boolean;
     speculativeDraftDflash?: boolean;
     speculativeDraftDspark?: boolean;
@@ -302,6 +303,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     contextLength,
     parallel: maxParallelPredictions,
     speculativeDraftMtp,
+    speculativeDraftOff,
     speculativeDraftSimple,
     speculativeDraftDflash,
     speculativeDraftDspark,
@@ -320,6 +322,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
     maxParallelPredictions,
     ...resolveCliSpeculativeDecodingLoadConfig({
       speculativeDraftMtp,
+      speculativeDraftOff,
       speculativeDraftSimple,
       speculativeDraftDflash,
       speculativeDraftDspark,

--- a/src/subcommands/load.ts
+++ b/src/subcommands/load.ts
@@ -338,7 +338,7 @@ loadCommand.action(async (modelKeyArg, options: LoadCommandOptions) => {
   );
   logger.debug(`Last loaded map loaded with ${lastLoadedMap.size} models.`);
 
-  const allDownloadedModels = (await client.system.listDownloadedModels())
+  const allDownloadedModels = (await client.system.listDownloadedModels({ includeDrafters: true }))
     .filter(model => model.architecture?.toLowerCase().includes("clip") !== true)
     .filter(model => (local ? model.deviceIdentifier === null : true))
     .sort((a, b) => {

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -10,7 +10,9 @@ export type CliSpeculativeConfig = Pick<
   | "speculativeDraftMaxTokens"
   | "speculativeDraftMinTokens"
   | "speculativeDraftMinContinueProbability"
->;
+> & {
+  speculativeDraftOff?: boolean;
+};
 
 type DraftSelectorField = Extract<
   keyof CliSpeculativeConfig,
@@ -65,6 +67,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   speculativeDraftSimple,
   speculativeDraftDflash,
   speculativeDraftDspark,
+  speculativeDraftOff,
   speculativeDraftModel,
   speculativeDraftMaxTokens,
   speculativeDraftMinTokens,
@@ -75,6 +78,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     speculativeDraftSimple,
     speculativeDraftDflash,
     speculativeDraftDspark,
+    speculativeDraftOff,
     speculativeDraftModel,
     speculativeDraftMaxTokens,
     speculativeDraftMinTokens,
@@ -85,6 +89,26 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     speculativeDraftMaxTokens !== undefined ||
     speculativeDraftMinTokens !== undefined ||
     speculativeDraftMinContinueProbability !== undefined;
+
+  if (speculativeDraftOff === true) {
+    if (enabledDraftModes.length > 0) {
+      throw new Error(
+        `--speculative-draft-off cannot be used with ${enabledDraftModes.map(({ flag }) => flag).join(" or ")}.`,
+      );
+    }
+    if (speculativeDraftModel !== undefined) {
+      throw new Error("--speculative-draft-off cannot be used with --speculative-draft-model.");
+    }
+    if (hasDraftTuning) {
+      throw new Error("--speculative-draft-off cannot be used with speculative draft tuning flags.");
+    }
+    return {
+      speculativeDraftMtp: false,
+      speculativeDraftSimple: false,
+      speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
+    };
+  }
 
   if (enabledDraftModes.length > 1) {
     throw new Error(
@@ -129,7 +153,8 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     speculativeDraftMtp === undefined &&
     speculativeDraftSimple === undefined &&
     speculativeDraftDflash === undefined &&
-    speculativeDraftDspark === undefined
+    speculativeDraftDspark === undefined &&
+    speculativeDraftOff === undefined
   ) {
     return {};
   }

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -4,6 +4,7 @@ export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
   speculativeDraftMtp?: boolean;
   speculativeDraftSimple?: boolean;
   speculativeDraftDflash?: boolean;
+  speculativeDraftDspark?: boolean;
   speculativeDraftModel?: string;
   speculativeDraftMaxTokens?: number;
   speculativeDraftMinTokens?: number;
@@ -14,6 +15,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   speculativeDraftMtp,
   speculativeDraftSimple,
   speculativeDraftDflash,
+  speculativeDraftDspark,
   speculativeDraftModel,
   speculativeDraftMaxTokens,
   speculativeDraftMinTokens,
@@ -23,6 +25,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   | "speculativeDraftMtp"
   | "speculativeDraftSimple"
   | "speculativeDraftDflash"
+  | "speculativeDraftDspark"
   | "speculativeDraftModel"
   | "speculativeDraftMaxTokens"
   | "speculativeDraftMinTokens"
@@ -32,6 +35,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     speculativeDraftMtp === true ? "--speculative-draft-mtp" : undefined,
     speculativeDraftSimple === true ? "--speculative-draft-simple" : undefined,
     speculativeDraftDflash === true ? "--speculative-draft-dflash" : undefined,
+    speculativeDraftDspark === true ? "--speculative-draft-dspark" : undefined,
   ].filter(mode => mode !== undefined);
   const hasDraftTuning =
     speculativeDraftMaxTokens !== undefined ||
@@ -48,7 +52,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
 
   if (speculativeDraftModel !== undefined && enabledDraftModes.length === 0) {
     throw new Error(
-      "--speculative-draft-model requires --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.",
+      "--speculative-draft-model requires --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark.",
     );
   }
 
@@ -60,9 +64,13 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     throw new Error("--speculative-draft-dflash requires --speculative-draft-model.");
   }
 
+  if (speculativeDraftDspark === true && speculativeDraftModel === undefined) {
+    throw new Error("--speculative-draft-dspark requires --speculative-draft-model.");
+  }
+
   if (enabledDraftModes.length === 0 && hasDraftTuning) {
     throw new Error(
-      "--speculative draft tuning flags require --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.",
+      "--speculative draft tuning flags require --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark.",
     );
   }
 
@@ -91,7 +99,8 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   if (
     speculativeDraftMtp === undefined &&
     speculativeDraftSimple === undefined &&
-    speculativeDraftDflash === undefined
+    speculativeDraftDflash === undefined &&
+    speculativeDraftDspark === undefined
   ) {
     return {};
   }
@@ -101,6 +110,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
       speculativeDraftMtp: true,
       speculativeDraftSimple: false,
       speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
       ...(speculativeDraftModel !== undefined ? { speculativeDraftModel } : {}),
       ...tuningConfig,
     };
@@ -111,6 +121,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
       speculativeDraftMtp: false,
       speculativeDraftSimple: true,
       speculativeDraftDflash: false,
+      speculativeDraftDspark: false,
       speculativeDraftModel,
       ...tuningConfig,
     };
@@ -121,6 +132,18 @@ export function resolveCliSpeculativeDecodingLoadConfig({
       speculativeDraftMtp: false,
       speculativeDraftSimple: false,
       speculativeDraftDflash: true,
+      speculativeDraftDspark: false,
+      speculativeDraftModel,
+      ...tuningConfig,
+    };
+  }
+
+  if (speculativeDraftDspark === true) {
+    return {
+      speculativeDraftMtp: false,
+      speculativeDraftSimple: false,
+      speculativeDraftDflash: false,
+      speculativeDraftDspark: true,
       speculativeDraftModel,
       ...tuningConfig,
     };

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -3,6 +3,7 @@ import { type LLMLoadModelConfig } from "@lmstudio/sdk";
 export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
   speculativeDraftMtp?: boolean;
   speculativeDraftSimple?: boolean;
+  speculativeDraftDflash?: boolean;
   speculativeDraftModel?: string;
   speculativeDraftMaxTokens?: number;
   speculativeDraftMinTokens?: number;
@@ -12,6 +13,7 @@ export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
 export function resolveCliSpeculativeDecodingLoadConfig({
   speculativeDraftMtp,
   speculativeDraftSimple,
+  speculativeDraftDflash,
   speculativeDraftModel,
   speculativeDraftMaxTokens,
   speculativeDraftMinTokens,
@@ -20,39 +22,47 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   LLMLoadModelConfig,
   | "speculativeDraftMtp"
   | "speculativeDraftSimple"
+  | "speculativeDraftDflash"
   | "speculativeDraftModel"
   | "speculativeDraftMaxTokens"
   | "speculativeDraftMinTokens"
   | "speculativeDraftMinContinueProbability"
 > {
+  const enabledDraftModes = [
+    speculativeDraftMtp === true ? "--speculative-draft-mtp" : undefined,
+    speculativeDraftSimple === true ? "--speculative-draft-simple" : undefined,
+    speculativeDraftDflash === true ? "--speculative-draft-dflash" : undefined,
+  ].filter(mode => mode !== undefined);
   const hasDraftTuning =
     speculativeDraftMaxTokens !== undefined ||
     speculativeDraftMinTokens !== undefined ||
     speculativeDraftMinContinueProbability !== undefined;
 
-  if (speculativeDraftMtp === true && speculativeDraftSimple === true) {
-    throw new Error("--speculative-draft-mtp and --speculative-draft-simple cannot both be used.");
+  if (enabledDraftModes.length > 1) {
+    throw new Error(`${enabledDraftModes.join(" and ")} cannot be used together.`);
   }
 
   if (speculativeDraftModel !== undefined && speculativeDraftModel.length === 0) {
     throw new Error("--speculative-draft-model must not be empty.");
   }
 
-  if (speculativeDraftMtp === true && speculativeDraftModel !== undefined) {
-    throw new Error("--speculative-draft-mtp cannot be combined with --speculative-draft-model.");
-  }
-
-  if (speculativeDraftSimple !== true && speculativeDraftModel !== undefined) {
-    throw new Error("--speculative-draft-model requires --speculative-draft-simple.");
+  if (speculativeDraftModel !== undefined && enabledDraftModes.length === 0) {
+    throw new Error(
+      "--speculative-draft-model requires --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.",
+    );
   }
 
   if (speculativeDraftSimple === true && speculativeDraftModel === undefined) {
     throw new Error("--speculative-draft-simple requires --speculative-draft-model.");
   }
 
-  if (speculativeDraftMtp !== true && speculativeDraftSimple !== true && hasDraftTuning) {
+  if (speculativeDraftDflash === true && speculativeDraftModel === undefined) {
+    throw new Error("--speculative-draft-dflash requires --speculative-draft-model.");
+  }
+
+  if (enabledDraftModes.length === 0 && hasDraftTuning) {
     throw new Error(
-      "--speculative draft tuning flags require --speculative-draft-simple or --speculative-draft-mtp.",
+      "--speculative draft tuning flags require --speculative-draft-simple, --speculative-draft-mtp, or --speculative-draft-dflash.",
     );
   }
 
@@ -78,31 +88,45 @@ export function resolveCliSpeculativeDecodingLoadConfig({
       : {}),
   };
 
-  if (speculativeDraftMtp === undefined && speculativeDraftSimple === undefined) {
+  if (
+    speculativeDraftMtp === undefined &&
+    speculativeDraftSimple === undefined &&
+    speculativeDraftDflash === undefined
+  ) {
     return {};
   }
 
   if (speculativeDraftMtp === true) {
     return {
       speculativeDraftMtp: true,
+      ...(speculativeDraftModel !== undefined ? { speculativeDraftModel } : {}),
       ...tuningConfig,
     };
   }
 
-  if (speculativeDraftMtp === false && speculativeDraftSimple !== true) {
+  if (speculativeDraftSimple === true) {
+    return {
+      speculativeDraftMtp: false,
+      speculativeDraftSimple: true,
+      speculativeDraftModel,
+      ...tuningConfig,
+    };
+  }
+
+  if (speculativeDraftDflash === true) {
+    return {
+      speculativeDraftMtp: false,
+      speculativeDraftDflash: true,
+      speculativeDraftModel,
+      ...tuningConfig,
+    };
+  }
+
+  if (speculativeDraftMtp === false) {
     return {
       speculativeDraftMtp: false,
     };
   }
 
-  if (speculativeDraftSimple !== true) {
-    return {};
-  }
-
-  return {
-    speculativeDraftMtp: false,
-    speculativeDraftSimple: true,
-    speculativeDraftModel: speculativeDraftModel,
-    ...tuningConfig,
-  };
+  return {};
 }

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -99,6 +99,8 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   if (speculativeDraftMtp === true) {
     return {
       speculativeDraftMtp: true,
+      speculativeDraftSimple: false,
+      speculativeDraftDflash: false,
       ...(speculativeDraftModel !== undefined ? { speculativeDraftModel } : {}),
       ...tuningConfig,
     };
@@ -108,6 +110,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     return {
       speculativeDraftMtp: false,
       speculativeDraftSimple: true,
+      speculativeDraftDflash: false,
       speculativeDraftModel,
       ...tuningConfig,
     };
@@ -116,6 +119,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   if (speculativeDraftDflash === true) {
     return {
       speculativeDraftMtp: false,
+      speculativeDraftSimple: false,
       speculativeDraftDflash: true,
       speculativeDraftModel,
       ...tuningConfig,

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -4,34 +4,15 @@ export type CliSpeculativeConfig = Pick<
   LLMLoadModelConfig,
   | "speculativeDraftMtp"
   | "speculativeDraftSimple"
-  | "speculativeDraftDflash"
-  | "speculativeDraftDspark"
   | "speculativeDraftModel"
   | "speculativeDraftMaxTokens"
   | "speculativeDraftMinTokens"
   | "speculativeDraftMinContinueProbability"
 > & {
+  mtp?: boolean;
+  drafter?: string | false;
   speculativeDraftOff?: boolean;
 };
-
-type DraftSelectorField = Extract<
-  keyof CliSpeculativeConfig,
-  | "speculativeDraftMtp"
-  | "speculativeDraftSimple"
-  | "speculativeDraftDflash"
-  | "speculativeDraftDspark"
->;
-
-const draftModeSpecs: Array<{
-  flag: string;
-  field: DraftSelectorField;
-  requiresModel: boolean;
-}> = [
-  { flag: "--speculative-draft-mtp", field: "speculativeDraftMtp", requiresModel: false },
-  { flag: "--speculative-draft-simple", field: "speculativeDraftSimple", requiresModel: true },
-  { flag: "--speculative-draft-dflash", field: "speculativeDraftDflash", requiresModel: true },
-  { flag: "--speculative-draft-dspark", field: "speculativeDraftDspark", requiresModel: true },
-];
 
 function getTuningConfig({
   speculativeDraftMaxTokens,
@@ -47,26 +28,23 @@ function getTuningConfig({
   };
 }
 
-function buildEnabledModeConfig(
-  selectedField: DraftSelectorField,
-  speculativeDraftModel: string | undefined,
-  tuningConfig: CliSpeculativeConfig,
-): CliSpeculativeConfig {
-  return {
-    speculativeDraftMtp: selectedField === "speculativeDraftMtp",
-    speculativeDraftSimple: selectedField === "speculativeDraftSimple",
-    speculativeDraftDflash: selectedField === "speculativeDraftDflash",
-    speculativeDraftDspark: selectedField === "speculativeDraftDspark",
-    ...(speculativeDraftModel !== undefined ? { speculativeDraftModel } : {}),
-    ...tuningConfig,
-  };
+function hasDraftTuning({
+  speculativeDraftMaxTokens,
+  speculativeDraftMinTokens,
+  speculativeDraftMinContinueProbability,
+}: CliSpeculativeConfig): boolean {
+  return (
+    speculativeDraftMaxTokens !== undefined ||
+    speculativeDraftMinTokens !== undefined ||
+    speculativeDraftMinContinueProbability !== undefined
+  );
 }
 
 export function resolveCliSpeculativeDecodingLoadConfig({
+  mtp,
+  drafter,
   speculativeDraftMtp,
   speculativeDraftSimple,
-  speculativeDraftDflash,
-  speculativeDraftDspark,
   speculativeDraftOff,
   speculativeDraftModel,
   speculativeDraftMaxTokens,
@@ -74,69 +52,63 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   speculativeDraftMinContinueProbability,
 }: CliSpeculativeConfig): CliSpeculativeConfig {
   const config: CliSpeculativeConfig = {
+    mtp,
+    drafter,
     speculativeDraftMtp,
     speculativeDraftSimple,
-    speculativeDraftDflash,
-    speculativeDraftDspark,
     speculativeDraftOff,
     speculativeDraftModel,
     speculativeDraftMaxTokens,
     speculativeDraftMinTokens,
     speculativeDraftMinContinueProbability,
   };
-  const enabledDraftModes = draftModeSpecs.filter(({ field }) => config[field] === true);
-  const hasDraftModel = typeof speculativeDraftModel === "string";
-  const hasDraftTuning =
-    speculativeDraftMaxTokens !== undefined ||
-    speculativeDraftMinTokens !== undefined ||
-    speculativeDraftMinContinueProbability !== undefined;
+  const tuningConfig = getTuningConfig(config);
+  const draftTuning = hasDraftTuning(config);
+  const explicitFullOff = drafter === false || speculativeDraftOff === true;
+  const preferredDrafter = typeof drafter === "string" ? drafter : undefined;
+  const legacyDrafter =
+    typeof speculativeDraftModel === "string" ? speculativeDraftModel : undefined;
+  const externalDrafter = preferredDrafter ?? legacyDrafter;
+  const requestedBundledMtp = mtp === true || speculativeDraftMtp === true;
 
-  if (speculativeDraftOff === true) {
-    if (enabledDraftModes.length > 0) {
-      throw new Error(
-        `--speculative-draft-off cannot be used with ${enabledDraftModes.map(({ flag }) => flag).join(" or ")}.`,
-      );
+  if (preferredDrafter !== undefined && legacyDrafter !== undefined) {
+    throw new Error("--drafter cannot be used with --speculative-draft-model.");
+  }
+
+  if (externalDrafter !== undefined && externalDrafter.length === 0) {
+    throw new Error("--drafter must not be empty.");
+  }
+
+  if (explicitFullOff) {
+    if (requestedBundledMtp) {
+      throw new Error("--no-drafter cannot be used with --mtp.");
     }
-    if (speculativeDraftModel !== undefined) {
-      throw new Error("--speculative-draft-off cannot be used with --speculative-draft-model.");
+    if (externalDrafter !== undefined) {
+      throw new Error("--no-drafter cannot be used with --drafter.");
     }
-    if (hasDraftTuning) {
-      throw new Error("--speculative-draft-off cannot be used with speculative draft tuning flags.");
+    if (speculativeDraftSimple === true) {
+      throw new Error("--no-drafter cannot be used with --speculative-draft-simple.");
+    }
+    if (draftTuning) {
+      throw new Error("--no-drafter cannot be used with speculative draft tuning flags.");
     }
     return {
       speculativeDraftMtp: false,
       speculativeDraftSimple: false,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
       speculativeDraftModel: false,
     };
   }
 
-  if (enabledDraftModes.length > 1) {
-    throw new Error(
-      `${enabledDraftModes.map(({ flag }) => flag).join(" and ")} cannot be used together.`,
-    );
+  if (mtp === true && externalDrafter !== undefined) {
+    throw new Error("--mtp cannot be used with --drafter.");
   }
 
-  if (hasDraftModel && speculativeDraftModel.length === 0) {
-    throw new Error("--speculative-draft-model must not be empty.");
+  if (speculativeDraftSimple === true && externalDrafter === undefined) {
+    throw new Error("--speculative-draft-simple requires --drafter.");
   }
 
-  if (hasDraftModel && enabledDraftModes.length === 0) {
-    throw new Error(
-      "--speculative-draft-model requires --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark.",
-    );
-  }
-
-  const enabledMode = enabledDraftModes[0];
-  if (enabledMode?.requiresModel === true && !hasDraftModel) {
-    throw new Error(`${enabledMode.flag} requires --speculative-draft-model.`);
-  }
-
-  if (enabledDraftModes.length === 0 && hasDraftTuning) {
-    throw new Error(
-      "--speculative draft tuning flags require --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark.",
-    );
+  if (draftTuning && externalDrafter === undefined && !requestedBundledMtp) {
+    throw new Error("speculative draft tuning flags require --drafter or --mtp.");
   }
 
   if (
@@ -149,24 +121,19 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     );
   }
 
-  const tuningConfig = getTuningConfig(config);
-
-  if (
-    speculativeDraftMtp === undefined &&
-    speculativeDraftSimple === undefined &&
-    speculativeDraftDflash === undefined &&
-    speculativeDraftDspark === undefined &&
-    speculativeDraftOff === undefined
-  ) {
-    return {};
+  if (externalDrafter !== undefined) {
+    return {
+      speculativeDraftMtp: false,
+      speculativeDraftModel: externalDrafter,
+      ...tuningConfig,
+    };
   }
 
-  if (enabledMode !== undefined) {
-    return buildEnabledModeConfig(
-      enabledMode.field,
-      hasDraftModel ? speculativeDraftModel : undefined,
-      tuningConfig,
-    );
+  if (requestedBundledMtp) {
+    return {
+      speculativeDraftMtp: true,
+      ...tuningConfig,
+    };
   }
 
   if (speculativeDraftMtp === false) {

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -85,6 +85,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     speculativeDraftMinContinueProbability,
   };
   const enabledDraftModes = draftModeSpecs.filter(({ field }) => config[field] === true);
+  const hasDraftModel = typeof speculativeDraftModel === "string";
   const hasDraftTuning =
     speculativeDraftMaxTokens !== undefined ||
     speculativeDraftMinTokens !== undefined ||
@@ -107,6 +108,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
       speculativeDraftSimple: false,
       speculativeDraftDflash: false,
       speculativeDraftDspark: false,
+      speculativeDraftModel: false,
     };
   }
 
@@ -116,18 +118,18 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     );
   }
 
-  if (speculativeDraftModel !== undefined && speculativeDraftModel.length === 0) {
+  if (hasDraftModel && speculativeDraftModel.length === 0) {
     throw new Error("--speculative-draft-model must not be empty.");
   }
 
-  if (speculativeDraftModel !== undefined && enabledDraftModes.length === 0) {
+  if (hasDraftModel && enabledDraftModes.length === 0) {
     throw new Error(
       "--speculative-draft-model requires --speculative-draft-simple, --speculative-draft-mtp, --speculative-draft-dflash, or --speculative-draft-dspark.",
     );
   }
 
   const enabledMode = enabledDraftModes[0];
-  if (enabledMode?.requiresModel === true && speculativeDraftModel === undefined) {
+  if (enabledMode?.requiresModel === true && !hasDraftModel) {
     throw new Error(`${enabledMode.flag} requires --speculative-draft-model.`);
   }
 
@@ -160,7 +162,11 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   }
 
   if (enabledMode !== undefined) {
-    return buildEnabledModeConfig(enabledMode.field, speculativeDraftModel, tuningConfig);
+    return buildEnabledModeConfig(
+      enabledMode.field,
+      hasDraftModel ? speculativeDraftModel : undefined,
+      tuningConfig,
+    );
   }
 
   if (speculativeDraftMtp === false) {

--- a/src/subcommands/loadSpeculativeDecoding.ts
+++ b/src/subcommands/loadSpeculativeDecoding.ts
@@ -1,14 +1,63 @@
 import { type LLMLoadModelConfig } from "@lmstudio/sdk";
 
-export interface ResolveCliSpeculativeDecodingLoadConfigOpts {
-  speculativeDraftMtp?: boolean;
-  speculativeDraftSimple?: boolean;
-  speculativeDraftDflash?: boolean;
-  speculativeDraftDspark?: boolean;
-  speculativeDraftModel?: string;
-  speculativeDraftMaxTokens?: number;
-  speculativeDraftMinTokens?: number;
-  speculativeDraftMinContinueProbability?: number;
+export type CliSpeculativeConfig = Pick<
+  LLMLoadModelConfig,
+  | "speculativeDraftMtp"
+  | "speculativeDraftSimple"
+  | "speculativeDraftDflash"
+  | "speculativeDraftDspark"
+  | "speculativeDraftModel"
+  | "speculativeDraftMaxTokens"
+  | "speculativeDraftMinTokens"
+  | "speculativeDraftMinContinueProbability"
+>;
+
+type DraftSelectorField = Extract<
+  keyof CliSpeculativeConfig,
+  | "speculativeDraftMtp"
+  | "speculativeDraftSimple"
+  | "speculativeDraftDflash"
+  | "speculativeDraftDspark"
+>;
+
+const draftModeSpecs: Array<{
+  flag: string;
+  field: DraftSelectorField;
+  requiresModel: boolean;
+}> = [
+  { flag: "--speculative-draft-mtp", field: "speculativeDraftMtp", requiresModel: false },
+  { flag: "--speculative-draft-simple", field: "speculativeDraftSimple", requiresModel: true },
+  { flag: "--speculative-draft-dflash", field: "speculativeDraftDflash", requiresModel: true },
+  { flag: "--speculative-draft-dspark", field: "speculativeDraftDspark", requiresModel: true },
+];
+
+function getTuningConfig({
+  speculativeDraftMaxTokens,
+  speculativeDraftMinTokens,
+  speculativeDraftMinContinueProbability,
+}: CliSpeculativeConfig): CliSpeculativeConfig {
+  return {
+    ...(speculativeDraftMaxTokens !== undefined ? { speculativeDraftMaxTokens } : {}),
+    ...(speculativeDraftMinTokens !== undefined ? { speculativeDraftMinTokens } : {}),
+    ...(speculativeDraftMinContinueProbability !== undefined
+      ? { speculativeDraftMinContinueProbability }
+      : {}),
+  };
+}
+
+function buildEnabledModeConfig(
+  selectedField: DraftSelectorField,
+  speculativeDraftModel: string | undefined,
+  tuningConfig: CliSpeculativeConfig,
+): CliSpeculativeConfig {
+  return {
+    speculativeDraftMtp: selectedField === "speculativeDraftMtp",
+    speculativeDraftSimple: selectedField === "speculativeDraftSimple",
+    speculativeDraftDflash: selectedField === "speculativeDraftDflash",
+    speculativeDraftDspark: selectedField === "speculativeDraftDspark",
+    ...(speculativeDraftModel !== undefined ? { speculativeDraftModel } : {}),
+    ...tuningConfig,
+  };
 }
 
 export function resolveCliSpeculativeDecodingLoadConfig({
@@ -20,30 +69,27 @@ export function resolveCliSpeculativeDecodingLoadConfig({
   speculativeDraftMaxTokens,
   speculativeDraftMinTokens,
   speculativeDraftMinContinueProbability,
-}: ResolveCliSpeculativeDecodingLoadConfigOpts): Pick<
-  LLMLoadModelConfig,
-  | "speculativeDraftMtp"
-  | "speculativeDraftSimple"
-  | "speculativeDraftDflash"
-  | "speculativeDraftDspark"
-  | "speculativeDraftModel"
-  | "speculativeDraftMaxTokens"
-  | "speculativeDraftMinTokens"
-  | "speculativeDraftMinContinueProbability"
-> {
-  const enabledDraftModes = [
-    speculativeDraftMtp === true ? "--speculative-draft-mtp" : undefined,
-    speculativeDraftSimple === true ? "--speculative-draft-simple" : undefined,
-    speculativeDraftDflash === true ? "--speculative-draft-dflash" : undefined,
-    speculativeDraftDspark === true ? "--speculative-draft-dspark" : undefined,
-  ].filter(mode => mode !== undefined);
+}: CliSpeculativeConfig): CliSpeculativeConfig {
+  const config: CliSpeculativeConfig = {
+    speculativeDraftMtp,
+    speculativeDraftSimple,
+    speculativeDraftDflash,
+    speculativeDraftDspark,
+    speculativeDraftModel,
+    speculativeDraftMaxTokens,
+    speculativeDraftMinTokens,
+    speculativeDraftMinContinueProbability,
+  };
+  const enabledDraftModes = draftModeSpecs.filter(({ field }) => config[field] === true);
   const hasDraftTuning =
     speculativeDraftMaxTokens !== undefined ||
     speculativeDraftMinTokens !== undefined ||
     speculativeDraftMinContinueProbability !== undefined;
 
   if (enabledDraftModes.length > 1) {
-    throw new Error(`${enabledDraftModes.join(" and ")} cannot be used together.`);
+    throw new Error(
+      `${enabledDraftModes.map(({ flag }) => flag).join(" and ")} cannot be used together.`,
+    );
   }
 
   if (speculativeDraftModel !== undefined && speculativeDraftModel.length === 0) {
@@ -56,16 +102,9 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     );
   }
 
-  if (speculativeDraftSimple === true && speculativeDraftModel === undefined) {
-    throw new Error("--speculative-draft-simple requires --speculative-draft-model.");
-  }
-
-  if (speculativeDraftDflash === true && speculativeDraftModel === undefined) {
-    throw new Error("--speculative-draft-dflash requires --speculative-draft-model.");
-  }
-
-  if (speculativeDraftDspark === true && speculativeDraftModel === undefined) {
-    throw new Error("--speculative-draft-dspark requires --speculative-draft-model.");
+  const enabledMode = enabledDraftModes[0];
+  if (enabledMode?.requiresModel === true && speculativeDraftModel === undefined) {
+    throw new Error(`${enabledMode.flag} requires --speculative-draft-model.`);
   }
 
   if (enabledDraftModes.length === 0 && hasDraftTuning) {
@@ -84,17 +123,7 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     );
   }
 
-  const tuningConfig = {
-    ...(speculativeDraftMaxTokens !== undefined
-      ? { speculativeDraftMaxTokens: speculativeDraftMaxTokens }
-      : {}),
-    ...(speculativeDraftMinTokens !== undefined
-      ? { speculativeDraftMinTokens: speculativeDraftMinTokens }
-      : {}),
-    ...(speculativeDraftMinContinueProbability !== undefined
-      ? { speculativeDraftMinContinueProbability: speculativeDraftMinContinueProbability }
-      : {}),
-  };
+  const tuningConfig = getTuningConfig(config);
 
   if (
     speculativeDraftMtp === undefined &&
@@ -105,48 +134,8 @@ export function resolveCliSpeculativeDecodingLoadConfig({
     return {};
   }
 
-  if (speculativeDraftMtp === true) {
-    return {
-      speculativeDraftMtp: true,
-      speculativeDraftSimple: false,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
-      ...(speculativeDraftModel !== undefined ? { speculativeDraftModel } : {}),
-      ...tuningConfig,
-    };
-  }
-
-  if (speculativeDraftSimple === true) {
-    return {
-      speculativeDraftMtp: false,
-      speculativeDraftSimple: true,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: false,
-      speculativeDraftModel,
-      ...tuningConfig,
-    };
-  }
-
-  if (speculativeDraftDflash === true) {
-    return {
-      speculativeDraftMtp: false,
-      speculativeDraftSimple: false,
-      speculativeDraftDflash: true,
-      speculativeDraftDspark: false,
-      speculativeDraftModel,
-      ...tuningConfig,
-    };
-  }
-
-  if (speculativeDraftDspark === true) {
-    return {
-      speculativeDraftMtp: false,
-      speculativeDraftSimple: false,
-      speculativeDraftDflash: false,
-      speculativeDraftDspark: true,
-      speculativeDraftModel,
-      ...tuningConfig,
-    };
+  if (enabledMode !== undefined) {
+    return buildEnabledModeConfig(enabledMode.field, speculativeDraftModel, tuningConfig);
   }
 
   if (speculativeDraftMtp === false) {

--- a/src/subcommands/loadTargetResolution.ts
+++ b/src/subcommands/loadTargetResolution.ts
@@ -1,0 +1,29 @@
+import { type ModelInfo } from "@lmstudio/sdk";
+
+export type CliLoadTargetModel = Pick<ModelInfo, "type" | "modelKey">;
+
+export function resolveExactDrafterLoadTarget<TModel extends CliLoadTargetModel>({
+  modelKey,
+  standaloneModels,
+  allDownloadedModels,
+}: {
+  modelKey: string | undefined;
+  standaloneModels: Array<TModel>;
+  allDownloadedModels: Array<TModel>;
+}): TModel | undefined {
+  const normalizedModelKey = modelKey?.toLowerCase();
+  if (normalizedModelKey === undefined) {
+    return undefined;
+  }
+
+  const exactStandaloneModel = standaloneModels.find(
+    model => model.modelKey.toLowerCase() === normalizedModelKey,
+  );
+  if (exactStandaloneModel !== undefined) {
+    return undefined;
+  }
+
+  return allDownloadedModels.find(
+    model => model.type === "drafter" && model.modelKey.toLowerCase() === normalizedModelKey,
+  );
+}


### PR DESCRIPTION
- `lms load`
  - Adds `--speculative-draft-dflash` for DFlash speculative decoding.
  - Adds `--speculative-draft-dspark` for DSpark speculative decoding.
  - Adds `--speculative-draft-off` to disable all speculative decoding modes for a load.
  - Deprecates `--no-speculative-draft-mtp`; use `--speculative-draft-off` to disable all modes.
  - Extends `--speculative-draft-model` to support DFlash, DSpark, and path-backed MTP draft models.

- `lms ls`
  - Adds `--drafter` to show only drafter models.